### PR TITLE
Set network fields in status on imported clusters

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -934,6 +934,14 @@ func (h *Handler) importCluster(config *v13.EKSClusterConfig, eksService *eks.EK
 		return config, err
 	}
 
+	config.Status.SecurityGroups = config.Spec.SecurityGroups
+	config.Status.Subnets = config.Spec.Subnets
+
+	config, err = h.eksCC.UpdateStatus(config)
+	if err != nil {
+		return config, err
+	}
+
 	if err := h.createCASecret(config.Name, config.Namespace, clusterState); err != nil {
 		return config, err
 	}


### PR DESCRIPTION
**Problem:**
When adding a nodegroup to an imported clusters an error is returned explaining that subnets are required. This is because if nodegroups do not have subnets set in spec they will use the same subnets as the cluster but networking fields in status for the cluster were not being properly set on import.

**Solution:**
Set networking fields in status on import.

**Issue:**
https://github.com/rancher/rancher/issues/28211