### PR TITLE
Add validation to create and update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace k8s.io/client-go => k8s.io/client-go v0.18.0
 
 require (
 	github.com/aws/aws-sdk-go v1.30.22
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/rancher/lasso v0.0.0-20200513231433-d0ce66327a25
 	github.com/rancher/wrangler v0.6.2-0.20200427172034-da9b142ae061
 	github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e


### PR DESCRIPTION
**Problem:**
Users need the option to upgrade nodegroup kubernetes versions the amazon way or to create new nodegroups and delete ones that are outdated.

**Solution:**
Nodegroup versions must now be maintained. Control plane cannot upgraded until all nodegroup versions match. New nodegroups' versions must match the control plane's version. Nodegroup versions can at most be 1 minor version less than the control plane's version.

**Issue:**
https://github.com/rancher/rancher/issues/27777