### PR TITLE
Add tag to subnets for elb compatibility

### DIFF
--- a/templates/template.go
+++ b/templates/template.go
@@ -117,6 +117,8 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub "${AWS::StackName}-Subnet01"
+      - Key: kubernetes.io/role/elb
+        Value: 1
 
   Subnet02:
     Type: AWS::EC2::Subnet
@@ -136,6 +138,8 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub "${AWS::StackName}-Subnet02"
+      - Key: kubernetes.io/role/elb
+        Value: 1
 
   Subnet03:
     Condition: HasMoreThan2Azs
@@ -156,6 +160,8 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub "${AWS::StackName}-Subnet03"
+      - Key: kubernetes.io/role/elb
+        Value: 1
 
   Subnet01RouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation


### PR DESCRIPTION
**Problem:**
Need networking tags for load balancer and elb compatibility in EKS.

**Solution:**
Add following tag:
kubernetes.io/role/elb: 1

**Notes:**
"kubernetes.io/cluster" tag is added by EKS. "kubernetes.io/role/internal-elb" does not apply because only public subnets are created for the user.

**Issue:**
https://github.com/rancher/rancher/issues/28332