### PR TITLE
Check length of instance types

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -684,7 +684,6 @@ func (h *Handler) buildUpstreamClusterState(name string, clusterState *eks.Descr
 		ngToAdd := v13.NodeGroup{
 			NodegroupName: aws.StringValue(ng.Nodegroup.NodegroupName),
 			DiskSize:      ng.Nodegroup.DiskSize,
-			InstanceType:  ng.Nodegroup.InstanceTypes[0],
 			Labels:        ng.Nodegroup.Labels,
 			DesiredSize:   ng.Nodegroup.ScalingConfig.DesiredSize,
 			MaxSize:       ng.Nodegroup.ScalingConfig.MaxSize,
@@ -692,6 +691,9 @@ func (h *Handler) buildUpstreamClusterState(name string, clusterState *eks.Descr
 			Subnets:       aws.StringValueSlice(ng.Nodegroup.Subnets),
 			Tags:          ng.Nodegroup.Tags,
 			Version:       ng.Nodegroup.Version,
+		}
+		if len(ng.Nodegroup.InstanceTypes) > 0 {
+			ngToAdd.InstanceType = ng.Nodegroup.InstanceTypes[0]
 		}
 		if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2X8664Gpu {
 			ngToAdd.Gpu = true


### PR DESCRIPTION
**Problem:**
Prior, importing clusters with nodegroups that don't have instance
types on their state would cause a nil. Nodegroups will not have
instance types if they are using a launch template. This is because
the instance types are instead described on the launch template.

**Solution:**
Now, the instance type will only be copied if it exists on the
nodegroup state.

**Issue:**
https://github.com/rancher/rancher/issues/28801