### PR TITLE
Check if CA secret exists

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -694,7 +694,9 @@ func (h *Handler) waitForCreationComplete(config *v13.EKSClusterConfig, eksServi
 
 	if status == eks.ClusterStatusActive {
 		if err := h.createCASecret(config.Name, config.Namespace, state); err != nil {
-			return config, err
+			if !errors.IsAlreadyExists(err) {
+				return config, err
+			}
 		}
 		logrus.Infof("cluster [%s] created successfully", config.Name)
 		config = config.DeepCopy()


### PR DESCRIPTION
If you create an EKS cluster on rancher, and then migrate rancher to a new cluster, the secret containing CA and endpoint for the eks cluster will already be on the local cluster. So this check prevents returning an error.