### PR TITLE
Add ssh key to upstream state

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -778,6 +778,9 @@ func BuildUpstreamClusterState(name string, clusterState *eks.DescribeClusterOut
 		if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2X8664Gpu {
 			ngToAdd.Gpu = aws.Bool(true)
 		}
+		if ng.Nodegroup.RemoteAccess != nil {
+			ngToAdd.Ec2SshKey = ng.Nodegroup.RemoteAccess.Ec2SshKey
+		}
 		upstreamSpec.NodeGroups = append(upstreamSpec.NodeGroups, ngToAdd)
 	}
 


### PR DESCRIPTION
**Problem:**
Ssh key is showing nil instead of proper value on spec. This is because the ssh key is not being included when building the upstream spec and then the upstream spec is being used to overwrite spec.

**Solution:**
Add ssh key when building upstream state.

**Issue:**
https://github.com/rancher/rancher/issues/28937