### PR TITLE
Require non-nil version for nodegroups

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -551,6 +551,9 @@ func validateCreate(config *v13.EKSClusterConfig) error {
 	for _, ng := range config.Spec.NodeGroups {
 		cannotBeNilError := "field [%s] cannot be nil for nodegroup [%s] in non-nil cluster [%s]"
 		if !config.Spec.Imported {
+			if ng.Version == nil {
+				return fmt.Errorf(cannotBeNilError, "version", *ng.NodegroupName, config.Name)
+			}
 			if ng.MinSize == nil {
 				return fmt.Errorf(cannotBeNilError, "minSize", *ng.NodegroupName, config.Name)
 			}


### PR DESCRIPTION
**Problem:**
Nodegroup version should be provided on create because it is required in EKS.

**Solution:**
Add validation that returns an error if a nodegroup's version is nil on create.

**Issue:**
https://github.com/rancher/rancher/issues/27777