### PR TITLE
Do not record cluster that are in deleting

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -761,6 +761,9 @@ func BuildUpstreamClusterState(name string, clusterState *eks.DescribeClusterOut
 	// set node groups
 	upstreamSpec.NodeGroups = make([]v13.NodeGroup, 0, len(nodeGroupStates))
 	for _, ng := range nodeGroupStates {
+		if aws.StringValue(ng.Nodegroup.Status) == eks.NodegroupStatusDeleting {
+			continue
+		}
 		ngToAdd := v13.NodeGroup{
 			NodegroupName: ng.Nodegroup.NodegroupName,
 			DiskSize:      ng.Nodegroup.DiskSize,
@@ -1057,7 +1060,7 @@ func (h *Handler) updateUpstreamClusterState(upstreamSpec *v13.EKSClusterConfigS
 			continue
 		}
 
-		if ng.Tags == nil {
+		if ng.Tags != nil {
 			if untags := utils.GetKeysToDelete(aws.StringValueMap(ng.Tags), aws.StringValueMap(upstreamNg.Tags)); untags != nil {
 				_, err := eksService.UntagResource(&eks.UntagResourceInput{
 					ResourceArn: aws.String(ngARNs[aws.StringValue(ng.NodegroupName)]),


### PR DESCRIPTION
**Problem:**
Prior, if a cluster was in deleting the refresh handler would overwrite spec with the cluster as though it were active. The eks-operator would wait for the cluster to finish updating and then it would recreate the cluster.

Also, tag updates were not being sent because they were only being checked for updates if tags was set to nil.

**Solution:**
Do not record cluster that are in deleting. Correctly check if the tags are not nil.

**Issue:**
https://github.com/rancher/rancher/issues/28967
https://github.com/rancher/rancher/issues/28951