### PR TITLE
Remove creation of extra security group

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -619,17 +619,15 @@ func (h *Handler) generateAndSetNetworking(svc *cloudformation.CloudFormation, c
 		}
 
 		virtualNetworkString := getParameterValueFromOutput("VpcId", stack.Stacks[0].Outputs)
-		securityGroupsString := getParameterValueFromOutput("SecurityGroups", stack.Stacks[0].Outputs)
 		subnetIdsString := getParameterValueFromOutput("SubnetIds", stack.Stacks[0].Outputs)
 
-		if securityGroupsString == "" || subnetIdsString == "" {
-			return config, fmt.Errorf("no security groups or subnet ids were returned")
+		if subnetIdsString == "" {
+			return config, fmt.Errorf("no subnet ids were returned")
 		}
 
 		config = config.DeepCopy()
 		// copy generated field to status
 		config.Status.VirtualNetwork = virtualNetworkString
-		config.Status.SecurityGroups = strings.Split(securityGroupsString, ",")
 		config.Status.Subnets = strings.Split(subnetIdsString, ",")
 		config.Status.NetworkFieldsSource = "generated"
 	}
@@ -878,7 +876,7 @@ func (h *Handler) updateUpstreamClusterState(upstreamSpec *eksv1.EKSClusterConfi
 			&eks.UpdateClusterConfigInput{
 				Name: aws.String(config.Spec.DisplayName),
 				ResourcesVpcConfig: &eks.VpcConfigRequest{
-					EndpointPublicAccess: config.Spec.PublicAccess,
+					EndpointPublicAccess:  config.Spec.PublicAccess,
 					EndpointPrivateAccess: config.Spec.PrivateAccess,
 				},
 			},

--- a/templates/template.go
+++ b/templates/template.go
@@ -182,12 +182,6 @@ Resources:
       SubnetId: !Ref Subnet03
       RouteTableId: !Ref RouteTable
 
-  ControlPlaneSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Cluster communication with worker nodes
-      VpcId: !Ref VPC
-
 Outputs:
 
   SubnetIds:
@@ -197,10 +191,6 @@ Outputs:
       - HasMoreThan2Azs
       - !Join [ ",", [ !Ref Subnet01, !Ref Subnet02, !Ref Subnet03 ] ]
       - !Join [ ",", [ !Ref Subnet01, !Ref Subnet02 ] ]
-
-  SecurityGroups:
-    Description: Security group for the cluster control plane communication with worker nodes
-    Value: !Join [ ",", [ !Ref ControlPlaneSecurityGroup ] ]
 
   VpcId:
     Description: The VPC Id


### PR DESCRIPTION
If a user did not specify a VPC, then the operator creates one. The
created VPC was also being created with a security group. However, when
the cluster is created, a security group is added automatically.
Therefore, the security group created with the VPC is extraneous.

Issue:
https://github.com/rancher/rancher/issues/29826