### PR TITLE
Use GPU instance type when selected

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -1326,6 +1326,12 @@ func createNodeGroup(eksConfig *eksv1.EKSClusterConfig, group eksv1.NodeGroup, e
 		},
 	}
 
+	if gpu := group.Gpu; aws.BoolValue(gpu) {
+		nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2X8664Gpu)
+	} else {
+		nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2X8664)
+	}
+
 	if sshKey := group.Ec2SshKey; aws.StringValue(sshKey) != "" {
 		nodeGroupCreateInput.RemoteAccess = &eks.RemoteAccessConfig{
 			Ec2SshKey: sshKey,


### PR DESCRIPTION
There was an omission that didn't include GPU instances if a user selected it in the UI.

Issue:
https://github.com/rancher/rancher/issues/29949