### PR TITLE
Fix gpu field going to `nil`

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -784,6 +784,8 @@ func BuildUpstreamClusterState(name string, clusterState *eks.DescribeClusterOut
 		}
 		if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2X8664Gpu {
 			ngToAdd.Gpu = aws.Bool(true)
+		} else if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2X8664 {
+			ngToAdd.Gpu = aws.Bool(false)
 		}
 		if ng.Nodegroup.RemoteAccess != nil {
 			ngToAdd.Ec2SshKey = ng.Nodegroup.RemoteAccess.Ec2SshKey


### PR DESCRIPTION
If the user did not select GPU images, then, during updating the upstream spec, the gpu field would be set to `nil`. This is incorrect because `nil` fields mean that field is not managed by Rancher, which is wrong in this case.

Issue:
https://github.com/rancher/rancher/issues/29949