### PR TITLE
Add helm annotation and required nodegroup field

### DIFF
--- a/crds/eksclusterconfig.yaml
+++ b/crds/eksclusterconfig.yaml
@@ -1,6 +1,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    helm.sh/resource-policy: keep
   name: eksclusterconfigs.eks.cattle.io
 spec:
   group: eks.cattle.io
@@ -119,6 +121,8 @@ spec:
                   version:
                     nullable: true
                     type: string
+                required:
+                - nodegroupName
                 type: object
               nullable: true
               type: array

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -67,9 +67,9 @@ type EKSClusterConfigStatus struct {
 type NodeGroup struct {
 	Gpu                  *bool              `json:"gpu"`
 	ImageID              *string            `json:"imageId"`
-	NodegroupName        *string            `json:"nodegroupName" norman:"required"`
+	NodegroupName        *string            `json:"nodegroupName" norman:"required" wrangler:"required"`
 	DiskSize             *int64             `json:"diskSize"`
-	InstanceType         *string            `json:"instanceType" norman:"required"`
+	InstanceType         *string            `json:"instanceType"`
 	Labels               map[string]*string `json:"labels"`
 	Ec2SshKey            *string            `json:"ec2SshKey"`
 	DesiredSize          *int64             `json:"desiredSize"`

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -51,6 +51,10 @@ func main() {
 		panic(err)
 	}
 
+	obj.ObjectMeta.Annotations = map[string]string{
+		"helm.sh/resource-policy": "keep",
+	}
+
 	eksCCYaml, err := yaml.Export(&obj)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Add a helm annotation to the the generated CRD. Also, add `nodegoupName` as a required field on the `NodeGroup` type.

Issue:
https://github.com/rancher/rancher/issues/30997