### PR TITLE
Encode fake userdata when creating launch template

### DIFF
--- a/controller/nodegroup.go
+++ b/controller/nodegroup.go
@@ -29,7 +29,7 @@ func createLaunchTemplate(clusterDisplayName string, ec2Service *ec2.EC2) (*eksv
 	// Since the default version cannot be deleted until the launch template is deleted, it will not be used for any node group.
 	// Also, launch templates cannot be created blank, so fake userdata is added to the first version.
 	launchTemplateCreateInput := &ec2.CreateLaunchTemplateInput{
-		LaunchTemplateData: &ec2.RequestLaunchTemplateData{UserData: aws.String("placeholder")},
+		LaunchTemplateData: &ec2.RequestLaunchTemplateData{UserData: aws.String("cGxhY2Vob2xkZXIK")},
 		LaunchTemplateName: aws.String(fmt.Sprintf(launchTemplateNameFormat, clusterDisplayName)),
 		TagSpecifications: []*ec2.TagSpecification{
 			{


### PR DESCRIPTION
The user data should be fully base64 encoded when creating the initial
launch template. The decoding is handled differently for different AWS
regions. This was tested to work with multiple regions.

Issue:
https://github.com/rancher/rancher/issues/31612