### PR TITLE
Add USER directive to Docker image

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,4 +4,5 @@ ENV KUBECONFIG /root/.kube/config
 RUN microdnf update -y && \
     rm -rf /var/cache/yum
 COPY bin/eks-operator /usr/bin/
+USER 1001
 ENTRYPOINT ["eks-operator"]


### PR DESCRIPTION
 In a hardened cluster, containers must not run as root user.
 Adding the USER directive changes the user to a non-root user, which
 allows the container to run in such environments.

Issues:
https://github.com/rancher/rancher/issues/29066
https://github.com/rancher/rancher/issues/33172