### PR TITLE
Fix label updates

### DIFF
--- a/controller/nodegroup_test.go
+++ b/controller/nodegroup_test.go
@@ -1,0 +1,1 @@
+package controller

--- a/controller/nodegroup_test.go
+++ b/controller/nodegroup_test.go
@@ -1,1 +1,138 @@
 package controller
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	v1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNodegroupConfigUpdate(t *testing.T) {
+	type nodegroupUpdateTestCase struct {
+		clusterName           string
+		ng1                   v1.NodeGroup
+		ng2                   v1.NodeGroup
+		expectedNgUpdateInput eks.UpdateNodegroupConfigInput
+		expectedNgNeedsUpdate bool
+	}
+	asserts := assert.New(t)
+	testCases := []nodegroupUpdateTestCase{
+		{
+			// test case where there should be no update
+			clusterName: "testcluster1",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster1"),
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				},
+			},
+			expectedNgNeedsUpdate: false,
+		},
+		{
+			// test the case where upstream doesn't have scaling fields MinSize or MaxSize size but desired does
+			clusterName: "testcluster2",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"})},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster2"),
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+		{
+			// test case where scaling field, DesiredSize, should be updated
+			clusterName: "testcluster3",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(3)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster3"),
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					DesiredSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+		{
+			// test case where label should be deleted
+			clusterName: "testcluster4",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster4"),
+				Labels: &eks.UpdateLabelsPayload{
+					RemoveLabels: aws.StringSlice([]string{"a"}),
+				},
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+		{
+			// test case where label should be added
+			clusterName: "testcluster5",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster5"),
+				Labels: &eks.UpdateLabelsPayload{
+					AddOrUpdateLabels: aws.StringMap(map[string]string{"a": "b"}),
+				},
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+		{
+			// test case where labels should be removed and added
+			clusterName: "testcluster6",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"c": "d", "e": "f", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster6"),
+				Labels: &eks.UpdateLabelsPayload{
+					RemoveLabels:      aws.StringSlice([]string{"c", "e"}),
+					AddOrUpdateLabels: aws.StringMap(map[string]string{"a": "b"}),
+				},
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+		{
+			// test case where label should be updated
+			clusterName: "testcluster7",
+			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "i"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
+				ClusterName: aws.String("testcluster7"),
+				Labels: &eks.UpdateLabelsPayload{
+					AddOrUpdateLabels: aws.StringMap(map[string]string{"g": "h"}),
+				},
+				ScalingConfig: &eks.NodegroupScalingConfig{
+					MinSize: aws.Int64(1),
+					MaxSize: aws.Int64(1),
+				}},
+			expectedNgNeedsUpdate: true,
+		},
+	}
+	for _, testCase := range testCases {
+		ngUpdateInput, ngNeedsUpdate := getNodegroupConfigUpdate(testCase.clusterName, testCase.ng1, testCase.ng2)
+		if ngUpdateInput.Labels != nil && len(ngUpdateInput.Labels.RemoveLabels) > 0 {
+			sortedRemovedLabels := aws.StringValueSlice(ngUpdateInput.Labels.RemoveLabels)
+			sort.Strings(sortedRemovedLabels)
+			ngUpdateInput.Labels.RemoveLabels = aws.StringSlice(sortedRemovedLabels)
+		}
+		asserts.Equal(testCase.expectedNgUpdateInput, ngUpdateInput)
+		asserts.Equal(testCase.expectedNgNeedsUpdate, ngNeedsUpdate)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/rancher/wrangler v0.7.3-0.20201020003736-e86bc912dfac
 	github.com/rancher/wrangler-api v0.6.1-0.20200427172631-a7c2f09b783e
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	k8s.io/api v0.18.8
 	k8s.io/apimachinery v0.18.8

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,5 +5,6 @@ set -e
 cd $(dirname $0)
 
 ./validate
+./test
 ./build
 ./package

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+cd $(dirname $0)/..
+
+echo 'Running: go test'
+GOPATH="" go test ./...

--- a/utils/map.go
+++ b/utils/map.go
@@ -33,8 +33,9 @@ func GetKeysToDelete(tags map[string]string, upstreamTags map[string]string) []*
 	}
 
 	var updateUntags []*string
-	for key, val := range upstreamTags {
-		if len(tags) == 0 || tags[key] != val {
+	for key := range upstreamTags {
+		_, ok := tags[key]
+		if len(tags) == 0 || !ok {
 			updateUntags = append(updateUntags, aws.String(key))
 		}
 	}

--- a/utils/map.go
+++ b/utils/map.go
@@ -35,7 +35,7 @@ func GetKeysToDelete(tags map[string]string, upstreamTags map[string]string) []*
 	var updateUntags []*string
 	for key := range upstreamTags {
 		_, ok := tags[key]
-		if len(tags) == 0 || !ok {
+		if !ok {
 			updateUntags = append(updateUntags, aws.String(key))
 		}
 	}


### PR DESCRIPTION
**Problem:**
Prior, if only a label update was necessary, the scaling config
fields were not included in the nodegroup config update. This
is considered invalid and will cause an error to be returned.


**Solution:**
Now, scaling config fields are included whether they need to be
updated or not. An additional bug has been fixed where if some
labels needed to be deleted and other updated, only the updated
labels would be added to the config update.

**Issue:**
https://github.com/rancher/rancher/issues/33302