### PR TITLE
Run c_rehash before launching the operator

### DIFF
--- a/charts/eks-operator/templates/deployment.yaml
+++ b/charts/eks-operator/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
         ke.cattle.io/operator: eks
     spec:
       serviceAccountName: eks-operator
+      securityContext:
+        fsGroup: 1007
+        runAsUser: 1007
       containers:
       - name: eks-operator
         image: {{ template "system_default_registry" . }}{{ .Values.eksOperator.image.repository }}:{{ .Values.eksOperator.image.tag }}
@@ -26,8 +29,16 @@ spec:
         - name: NO_PROXY
           value: {{ .Values.noProxy }}
 {{- if .Values.additionalTrustedCAs }}
+        # eks-operator mounts the additional CAs in two places:
         volumeMounts:
-          - mountPath: /etc/ssl/certs/ca-additional.pem
+            # This directory is owned by the eks-operator user so c_rehash works here.
+          - mountPath: /etc/rancher/ssl/ca-additional.pem
+            name: tls-ca-additional-volume
+            subPath: ca-additional.pem
+            readOnly: true
+            # This directory is root-owned so c_rehash doesn't work here,
+            # but the cert is here in case update-ca-certificates is called in the future or by the OS.
+          - mountPath: /etc/pki/trust/anchors/ca-additional.pem
             name: tls-ca-additional-volume
             subPath: ca-additional.pem
             readOnly: true

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,6 +4,14 @@ RUN zypper -n update && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
 RUN useradd --uid 1007 eks-operator
 ENV KUBECONFIG /home/eks-operator/.kube/config
+ENV SSL_CERT_DIR /etc/rancher/ssl
+
 COPY bin/eks-operator /usr/bin/
+COPY package/entrypoint.sh /usr/bin
+RUN chmod +x /usr/bin/entrypoint.sh
+
+RUN mkdir -p /etc/rancher/ssl && \
+    chown -R eks-operator /etc/rancher/ssl
+
 USER 1007
-ENTRYPOINT ["eks-operator"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ -x "$(command -v c_rehash)" ]; then
+  # c_rehash is run here instead of update-ca-certificates because the latter requires root privileges
+  # and the eks-operator container is run as non-root user.
+  c_rehash
+fi
+eks-operator


### PR DESCRIPTION
The SLE image requires that c_rehash is run before additional trusted CAs
will be detected. Therefore, an entrypoint script is added to accomplish
this.

In addition, fsGroup is added so that c_rehash (which is run as the
eks-operator user) can read the cert that is mounted.

Issue:
https://github.com/rancher/rancher/issues/31846