### PR TITLE
[backport] Add USER directive to image for hardened clusters

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,4 +4,5 @@ ENV KUBECONFIG /root/.kube/config
 RUN microdnf update -y && \
     rm -rf /var/cache/yum
 COPY bin/eks-operator /usr/bin/
+USER 1001
 ENTRYPOINT ["eks-operator"]


### PR DESCRIPTION
Running the container as a non-root user allows it run on hardened clusters.

Issue:
https://github.com/rancher/rancher/issues/33172

Original PR:
https://github.com/rancher/eks-operator/pull/42