### PR TITLE
Use SLES base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 bin/
 dist/
+.dapper

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,17 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest
-FROM ${UBI_IMAGE}
-ENV KUBECONFIG /root/.kube/config
-RUN microdnf update -y && \
-    rm -rf /var/cache/yum
+FROM registry.suse.com/suse/sle15:15.3
+RUN zypper -n update && \
+    zypper -n clean -a && \
+    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
+RUN useradd --uid 1007 eks-operator
+ENV KUBECONFIG /home/eks-operator/.kube/config
+ENV SSL_CERT_DIR /etc/rancher/ssl
+
 COPY bin/eks-operator /usr/bin/
-USER 1001
-ENTRYPOINT ["eks-operator"]
+COPY package/entrypoint.sh /usr/bin
+RUN chmod +x /usr/bin/entrypoint.sh
+
+RUN mkdir -p /etc/rancher/ssl && \
+    chown -R eks-operator /etc/rancher/ssl
+
+USER 1007
+ENTRYPOINT ["entrypoint.sh"]

--- a/package/entrypoint.sh
+++ b/package/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ -x "$(command -v c_rehash)" ]; then
+  # c_rehash is run here instead of update-ca-certificates because the latter requires root privileges
+  # and the eks-operator container is run as non-root user.
+  c_rehash
+fi
+eks-operator


### PR DESCRIPTION
This is a backport of a change in 2.6. Using the SLES image, combined
with USER changes, allow additional certificates to be passed to the
container for situations when Rancher is run behind a proxy.

Issue:
https://github.com/rancher/rancher/issues/32903