### PR TITLE
Enable node group node role

### DIFF
--- a/charts/eks-operator-crd/templates/crds.yaml
+++ b/charts/eks-operator-crd/templates/crds.yaml
@@ -87,6 +87,9 @@ spec:
                     minSize:
                       nullable: true
                       type: integer
+                    nodeRole:
+                      nullable: true
+                      type: string
                     nodegroupName:
                       nullable: true
                       type: string

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -620,6 +620,9 @@ func (h *Handler) validateCreate(config *eksv1.EKSClusterConfig, eksService *eks
 			if ng.RequestSpotInstances == nil {
 				return fmt.Errorf(cannotBeNilError, "requestSpotInstances", *ng.NodegroupName, config.Name)
 			}
+			if ng.NodeRole == nil {
+				return fmt.Errorf(cannotBeNilError, "nodeRole", *ng.NodegroupName, config.Name)
+			}
 			if aws.BoolValue(ng.RequestSpotInstances) {
 				if len(ng.SpotInstanceTypes) == 0 {
 					return fmt.Errorf("nodegroup [%s] in cluster [%s]: spotInstanceTypes must be specified when requesting spot instances", *ng.NodegroupName, config.Name)
@@ -819,6 +822,7 @@ func BuildUpstreamClusterState(name, managedTemplateID string, clusterState *eks
 			Tags:                 ng.Nodegroup.Tags,
 			Version:              ng.Nodegroup.Version,
 			RequestSpotInstances: aws.Bool(aws.StringValue(ng.Nodegroup.CapacityType) == eks.CapacityTypesSpot),
+			NodeRole:             ng.Nodegroup.NodeRole,
 		}
 
 		if aws.BoolValue(ngToAdd.RequestSpotInstances) {

--- a/controller/nodegroup.go
+++ b/controller/nodegroup.go
@@ -253,13 +253,15 @@ func createNodeGroup(config *eksv1.EKSClusterConfig, group eksv1.NodeGroup, eksS
 		nodeGroupCreateInput.Subnets = aws.StringSlice(config.Status.Subnets)
 	}
 
-	finalTemplate := fmt.Sprintf(templates.NodeInstanceRoleTemplate, getEC2ServiceEndpoint(config.Spec.Region))
-	output, err := createStack(svc, fmt.Sprintf("%s-node-instance-role", config.Spec.DisplayName), config.Spec.DisplayName, finalTemplate, []string{cloudformation.CapabilityCapabilityIam}, []*cloudformation.Parameter{})
-	if err != nil {
-		return "", err
+	if aws.StringValue(group.NodeRole) == "" {
+		finalTemplate := fmt.Sprintf(templates.NodeInstanceRoleTemplate, getEC2ServiceEndpoint(config.Spec.Region))
+		output, err := createStack(svc, fmt.Sprintf("%s-node-instance-role", config.Spec.DisplayName), config.Spec.DisplayName, finalTemplate, []string{cloudformation.CapabilityCapabilityIam}, []*cloudformation.Parameter{})
+		if err != nil {
+			return "", err
+		}
+		nodeGroupCreateInput.NodeRole = aws.String(getParameterValueFromOutput("NodeInstanceRole", output.Stacks[0].Outputs))
 	}
 
-	nodeGroupCreateInput.NodeRole = aws.String(getParameterValueFromOutput("NodeInstanceRole", output.Stacks[0].Outputs))
 	_, err = eksService.CreateNodegroup(nodeGroupCreateInput)
 	if err != nil {
 		// If there was an error creating the node group, then the template version should be deleted

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -83,7 +83,7 @@ type NodeGroup struct {
 	LaunchTemplate       *LaunchTemplate    `json:"launchTemplate"`
 	RequestSpotInstances *bool              `json:"requestSpotInstances"`
 	SpotInstanceTypes    []*string          `json:"spotInstanceTypes" norman:"pointer"`
-	NodeRole      		 *string            `json:"nodeRole" norman:"pointer"`
+	NodeRole             *string            `json:"nodeRole" norman:"pointer"`
 }
 
 type LaunchTemplate struct {

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -83,6 +83,7 @@ type NodeGroup struct {
 	LaunchTemplate       *LaunchTemplate    `json:"launchTemplate"`
 	RequestSpotInstances *bool              `json:"requestSpotInstances"`
 	SpotInstanceTypes    []*string          `json:"spotInstanceTypes" norman:"pointer"`
+	NodeRole      		 *string            `json:"nodeRole" norman:"pointer"`
 }
 
 type LaunchTemplate struct {

--- a/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
@@ -363,6 +363,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 			}
 		}
 	}
+	if in.NodeRole != nil {
+		in, out := &in.NodeRole, &out.NodeRole
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This is a feature to add a node group role for eks node groups to Rancher created node groups. Here is the issue it is associated with. 