### PR TITLE
Add kube-version annotation to chart

### DIFF
--- a/charts/eks-operator/Chart.yaml
+++ b/charts/eks-operator/Chart.yaml
@@ -10,9 +10,10 @@ annotations:
   catalog.cattle.io/auto-install: rancher-eks-operator-crd=match
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/hidden: "true"
-  catalog.cattle.io/scope: management
+  catalog.cattle.io/kube-version: ">= 1.18.0-0"
   catalog.cattle.io/namespace: cattle-system
-  catalog.cattle.io/release-name: rancher-eks-operator
-  catalog.cattle.io/provides-gvr: eksclusterconfigs.eks.cattle.io/v1
   catalog.cattle.io/os: linux
+  catalog.cattle.io/provides-gvr: eksclusterconfigs.eks.cattle.io/v1
   catalog.cattle.io/rancher-version: ">= 2.6.0-alpha"
+  catalog.cattle.io/release-name: rancher-eks-operator
+  catalog.cattle.io/scope: management


### PR DESCRIPTION
The annotations were also rearranged to be in alphabetical order.

Issue:
https://github.com/rancher/rancher/issues/35100