### PR TITLE
Remove norman:pointer tags from EKS operator

### DIFF
--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -38,17 +38,17 @@ type EKSClusterConfigSpec struct {
 	Region                 string            `json:"region" norman:"noupdate"`
 	Imported               bool              `json:"imported" norman:"noupdate"`
 	KubernetesVersion      *string           `json:"kubernetesVersion" norman:"pointer"`
-	Tags                   map[string]string `json:"tags" norman:"pointer"`
+	Tags                   map[string]string `json:"tags"`
 	SecretsEncryption      *bool             `json:"secretsEncryption" norman:"noupdate"`
 	KmsKey                 *string           `json:"kmsKey" norman:"noupdate,pointer"`
 	PublicAccess           *bool             `json:"publicAccess"`
 	PrivateAccess          *bool             `json:"privateAccess"`
-	PublicAccessSources    []string          `json:"publicAccessSources" norman:"pointer"`
-	LoggingTypes           []string          `json:"loggingTypes" norman:"pointer"`
-	Subnets                []string          `json:"subnets" norman:"noupdate,pointer"`
-	SecurityGroups         []string          `json:"securityGroups" norman:"noupdate,pointer"`
+	PublicAccessSources    []string          `json:"publicAccessSources"`
+	LoggingTypes           []string          `json:"loggingTypes"`
+	Subnets                []string          `json:"subnets" norman:"noupdate"`
+	SecurityGroups         []string          `json:"securityGroups" norman:"noupdate"`
 	ServiceRole            *string           `json:"serviceRole" norman:"noupdate,pointer"`
-	NodeGroups             []NodeGroup       `json:"nodeGroups" norman:"pointer"`
+	NodeGroups             []NodeGroup       `json:"nodeGroups"`
 }
 
 type EKSClusterConfigStatus struct {
@@ -70,19 +70,19 @@ type NodeGroup struct {
 	NodegroupName        *string            `json:"nodegroupName" norman:"required,pointer" wrangler:"required"`
 	DiskSize             *int64             `json:"diskSize"`
 	InstanceType         *string            `json:"instanceType" norman:"pointer"`
-	Labels               map[string]*string `json:"labels" norman:"pointer"`
+	Labels               map[string]*string `json:"labels"`
 	Ec2SshKey            *string            `json:"ec2SshKey" norman:"pointer"`
 	DesiredSize          *int64             `json:"desiredSize"`
 	MaxSize              *int64             `json:"maxSize"`
 	MinSize              *int64             `json:"minSize"`
-	Subnets              []string           `json:"subnets" norman:"pointer"`
-	Tags                 map[string]*string `json:"tags" norman:"pointer"`
-	ResourceTags         map[string]*string `json:"resourceTags" norman:"pointer"`
+	Subnets              []string           `json:"subnets"`
+	Tags                 map[string]*string `json:"tags"`
+	ResourceTags         map[string]*string `json:"resourceTags"`
 	UserData             *string            `json:"userData" norman:"pointer"`
 	Version              *string            `json:"version" norman:"pointer"`
 	LaunchTemplate       *LaunchTemplate    `json:"launchTemplate"`
 	RequestSpotInstances *bool              `json:"requestSpotInstances"`
-	SpotInstanceTypes    []*string          `json:"spotInstanceTypes" norman:"pointer"`
+	SpotInstanceTypes    []*string          `json:"spotInstanceTypes"`
 }
 
 type LaunchTemplate struct {


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/36128.

A KEv2 cluster imported with the rancher2 terraform provider will currently delete all node groups on import if no node groups are specified in the terraform config. 

This is happening because the `NodeGroups` cluster config field (and all slices and maps) in the KEv2 operators have the `norman:pointer` tag. The problem is that the `norman:pointer` tag is added to fields that are already pointers. When node groups is not specified in the terraform config, terraform sets the node group field in the management cluster yaml as an empty array instead of null. If node groups is an empty array, Rancher deletes all node groups from the imported cluster because that is the template given: no node groups. Removing the incorrect tag will make node groups null and Rancher will take no action against imported clusters.

This fix is being made in the EKS, AKS, and GKE operators so node groups will never get deleted when a user tries to import a cluster with terraform.