### PR TITLE
Fix vpc no security group case

### DIFF
--- a/controller/nodegroup.go
+++ b/controller/nodegroup.go
@@ -105,7 +105,7 @@ func buildLaunchTemplateData(group eksv1.NodeGroup, securityGroups []string, ec2
 	// If the user specifies a custom VPC in the launch template, we are using security groups
 	// so add the security group IDs.
 	var securityGroupIds []*string
-	if securityGroups != nil {
+	if len(securityGroups) > 0 {
 		securityGroupIds = aws.StringSlice(securityGroups)
 	}
 


### PR DESCRIPTION
# PR Template

Issue: https://github.com/rancher/rancher/issues/34749 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->

Fixed edge case where when creating a custom EKS cluster in Rancher, you can select a custom VPC but no security groups and provisioning will succeed.
 
## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->