### PR TITLE
Revert add rancher security groups to launch template

### DIFF
--- a/controller/nodegroup.go
+++ b/controller/nodegroup.go
@@ -56,8 +56,8 @@ func createLaunchTemplate(clusterDisplayName string, ec2Service *ec2.EC2) (*eksv
 	}, nil
 }
 
-func createNewLaunchTemplateVersion(launchTemplateID string, securityGroups []string, group eksv1.NodeGroup, ec2Service *ec2.EC2) (*eksv1.LaunchTemplate, error) {
-	launchTemplate, err := buildLaunchTemplateData(group, securityGroups, ec2Service)
+func createNewLaunchTemplateVersion(launchTemplateID string, group eksv1.NodeGroup, ec2Service *ec2.EC2) (*eksv1.LaunchTemplate, error) {
+	launchTemplate, err := buildLaunchTemplateData(group, ec2Service)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func createNewLaunchTemplateVersion(launchTemplateID string, securityGroups []st
 	}, nil
 }
 
-func buildLaunchTemplateData(group eksv1.NodeGroup, securityGroups []string, ec2Service *ec2.EC2) (*ec2.RequestLaunchTemplateData, error) {
+func buildLaunchTemplateData(group eksv1.NodeGroup, ec2Service *ec2.EC2) (*ec2.RequestLaunchTemplateData, error) {
 	var imageID *string
 	if aws.StringValue(group.ImageID) != "" {
 		imageID = group.ImageID
@@ -102,13 +102,6 @@ func buildLaunchTemplateData(group eksv1.NodeGroup, securityGroups []string, ec2
 		}
 	}
 
-	// If the user specifies a custom VPC in the launch template, we are using security groups
-	// so add the security group IDs.
-	var securityGroupIds []*string
-	if len(securityGroups) > 0 {
-		securityGroupIds = aws.StringSlice(securityGroups)
-	}
-
 	launchTemplateData := &ec2.RequestLaunchTemplateData{
 		ImageId:  imageID,
 		KeyName:  group.Ec2SshKey,
@@ -122,7 +115,6 @@ func buildLaunchTemplateData(group eksv1.NodeGroup, securityGroups []string, ec2
 			},
 		},
 		TagSpecifications: utils.CreateTagSpecs(group.ResourceTags),
-		SecurityGroupIds:  securityGroupIds,
 	}
 	if !aws.BoolValue(group.RequestSpotInstances) {
 		launchTemplateData.InstanceType = group.InstanceType
@@ -138,7 +130,7 @@ func newLaunchTemplateVersionIfNeeded(config *eksv1.EKSClusterConfig, upstreamNg
 		aws.StringValue(upstreamNg.ImageID) != aws.StringValue(ng.ImageID) ||
 		(!aws.BoolValue(upstreamNg.RequestSpotInstances) && aws.StringValue(upstreamNg.InstanceType) != aws.StringValue(ng.InstanceType)) ||
 		!utils.CompareStringMaps(aws.StringValueMap(upstreamNg.ResourceTags), aws.StringValueMap(ng.ResourceTags)) {
-		lt, err := createNewLaunchTemplateVersion(config.Status.ManagedLaunchTemplateID, config.Status.SecurityGroups, ng, ec2Service)
+		lt, err := createNewLaunchTemplateVersion(config.Status.ManagedLaunchTemplateID, ng, ec2Service)
 		if err != nil {
 			return nil, err
 		}
@@ -227,7 +219,7 @@ func createNodeGroup(config *eksv1.EKSClusterConfig, group eksv1.NodeGroup, eksS
 	if lt == nil {
 		// In this case, the user has not specified their own launch template.
 		// If the cluster doesn't have a launch template associated with it, then we create one.
-		lt, err = createNewLaunchTemplateVersion(config.Status.ManagedLaunchTemplateID, config.Status.SecurityGroups, group, ec2Service)
+		lt, err = createNewLaunchTemplateVersion(config.Status.ManagedLaunchTemplateID, group, ec2Service)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/38014

This PR https://github.com/rancher/eks-operator/pull/60 is being reverted after a design discussion whose conclusion was this: _we want how rancher handles security groups in EKS to have parity with vanilla EKS_. EKS will only add the default security group to node instances _unless_ there are security group(s) on the launch template, in which case those security group(s) replace the default on the nodes. Rancher will not add custom security groups to the launch template; any security groups defined by the user in the rancher UI will only be added at cluster level.