### PR TITLE
Run make generate

### DIFF
--- a/pkg/generated/controllers/core/factory.go
+++ b/pkg/generated/controllers/core/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package core
 
 import (
+	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/wrangler/pkg/generic"
 	"k8s.io/client-go/rest"
 )
@@ -64,4 +65,8 @@ func NewFactoryFromConfigWithOptionsOrDie(config *rest.Config, opts *FactoryOpti
 
 func (c *Factory) Core() Interface {
 	return New(c.ControllerFactory())
+}
+
+func (c *Factory) WithAgent(userAgent string) Interface {
+	return New(controller.NewSharedControllerFactoryWithAgent(userAgent, c.ControllerFactory()))
 }

--- a/pkg/generated/controllers/eks.cattle.io/factory.go
+++ b/pkg/generated/controllers/eks.cattle.io/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package eks
 
 import (
+	"github.com/rancher/lasso/pkg/controller"
 	"github.com/rancher/wrangler/pkg/generic"
 	"k8s.io/client-go/rest"
 )
@@ -64,4 +65,8 @@ func NewFactoryFromConfigWithOptionsOrDie(config *rest.Config, opts *FactoryOpti
 
 func (c *Factory) Eks() Interface {
 	return New(c.ControllerFactory())
+}
+
+func (c *Factory) WithAgent(userAgent string) Interface {
+	return New(controller.NewSharedControllerFactoryWithAgent(userAgent, c.ControllerFactory()))
 }


### PR DESCRIPTION
Run make generate to fix CI failures, `make verify` fails because of outdated controllers.