### PR TITLE
Allow nil node role in cluster spec

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -559,7 +559,7 @@ func (h *Handler) validateCreate(config *eksv1.EKSClusterConfig) error {
 				return fmt.Errorf(cannotBeNilError, "requestSpotInstances", *ng.NodegroupName, config.Name)
 			}
 			if ng.NodeRole == nil {
-				return fmt.Errorf(cannotBeNilError, "nodeRole", *ng.NodegroupName, config.Name)
+				logrus.Warnf("nodeRole is not specified for nodegroup [%s] in cluster [%s], the controller will generate it", *ng.NodegroupName, config.Name)
 			}
 			if aws.BoolValue(ng.RequestSpotInstances) {
 				if len(ng.SpotInstanceTypes) == 0 {

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -74,7 +74,7 @@ type CreateStackOptions struct {
 func CreateStack(opts CreateStackOptions) (*cloudformation.DescribeStacksOutput, error) {
 	_, err := opts.CloudFormationService.CreateStack(&cloudformation.CreateStackInput{
 		StackName:    aws.String(opts.StackName),
-		TemplateBody: aws.String(opts.StackName),
+		TemplateBody: aws.String(opts.TemplateBody),
 		Capabilities: aws.StringSlice(opts.Capabilities),
 		Parameters:   opts.Parameters,
 		Tags: []*cloudformation.Tag{

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -144,7 +144,7 @@ var _ = Describe("CreateStack", func() {
 			CloudFormationService: cloudFormationsServiceMock,
 			StackName:             "test",
 			DisplayName:           "test",
-			TemplateBody:          "test",
+			TemplateBody:          "test-body",
 			Capabilities:          []string{"test"},
 			Parameters:            []*cloudformation.Parameter{{ParameterKey: aws.String("test"), ParameterValue: aws.String("test")}},
 		}

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -19,7 +19,6 @@ spec:
     launchTemplate: null
     maxSize: 2
     minSize: 2
-    nodeRole: ""
     nodegroupName: nodenametest
     requestSpotInstances: false
     resourceTags: {}


### PR DESCRIPTION
Allow nil node role in cluster spec will result in a node role being generated by the controller https://github.com/rancher/eks-operator/blob/master/controller/nodegroup.go#L261. Currently `""` is the only allowed option for generating a new node role but from our code logic point of view it shouldn't matter because we already treat empty strings and nil values the same.
I also made this field nil in our e2e so we can capture this case too.

https://github.com/rancher/rancher/issues/41123