### PR TITLE
🌱 Enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,17 +1,32 @@
 run:
   timeout: 5m
+  go: "1.19"
   skip-files:
     - "zz_generated_*"
   tests: false
+  allow-parallel-runners: true
+
 output:
   format: github-actions
+
 linters:
+  disable-all: true
   enable:
-    - revive # replacement for golint
     - dupl # check duplicated code
     - goconst # check strings that can turn into constants
     - gofmt # check fmt
     - goimports # check imports
+    - gosec # check for security problems
+    - govet # check vet
+    - importas # check consistent import aliasing
+    - ineffassign # check ineffectual assignments
+    - misspell # check for misspelled English words
+    - nakedret # check naked returns in functions
+    - prealloc # check preallocated slice declarations
+    - revive # replacement for golint
+    - unconvert # check redundant type conversions
+    - whitespace # check for trailing whitespace and tabs
+
 linters-settings:
   revive:
     rules:
@@ -39,6 +54,31 @@ linters-settings:
       - name: unreachable-code
       - name: redefines-builtin-id
       - name: unexported-return
+  importas:
+    no-unaliased: true
+    alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/util/runtime
+        alias: utilruntime
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client
+        alias: runtimeclient
+      # Rancher EKS operator
+      - pkg: github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1
+        alias: eksv1
+      - pkg: github.com/rancher/eks-operator/pkg/generated/controllers/eks.cattle.io/v1
+        alias: ekscontrollers
+      - pkg: github.com/rancher/eks-operator/pkg/eks
+        alias: awsservices
+      # Core Rancher
+      - pkg: github.com/rancher/rancher/pkg/apis/management.cattle.io/v3
+        alias: managementv3
+
 issues:
   exclude-rules:
   - linters:

--- a/controller/nodegroup_test.go
+++ b/controller/nodegroup_test.go
@@ -6,15 +6,15 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
-	v1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
+	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetNodegroupConfigUpdate(t *testing.T) {
 	type nodegroupUpdateTestCase struct {
 		clusterName           string
-		ng1                   v1.NodeGroup
-		ng2                   v1.NodeGroup
+		ng1                   eksv1.NodeGroup
+		ng2                   eksv1.NodeGroup
 		expectedNgUpdateInput eks.UpdateNodegroupConfigInput
 		expectedNgNeedsUpdate bool
 	}
@@ -23,8 +23,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where there should be no update
 			clusterName: "testcluster1",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster1"),
 				ScalingConfig: &eks.NodegroupScalingConfig{
@@ -37,8 +37,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test the case where upstream doesn't have scaling fields MinSize or MaxSize size but desired does
 			clusterName: "testcluster2",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"})},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"})},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster2"),
 				ScalingConfig: &eks.NodegroupScalingConfig{
@@ -50,8 +50,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where scaling field, DesiredSize, should be updated
 			clusterName: "testcluster3",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(3)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), DesiredSize: aws.Int64(3)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster3"),
 				ScalingConfig: &eks.NodegroupScalingConfig{
@@ -62,8 +62,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where label should be deleted
 			clusterName: "testcluster4",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster4"),
 				Labels: &eks.UpdateLabelsPayload{
@@ -78,8 +78,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where label should be added
 			clusterName: "testcluster5",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster5"),
 				Labels: &eks.UpdateLabelsPayload{
@@ -94,8 +94,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where labels should be removed and added
 			clusterName: "testcluster6",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"c": "d", "e": "f", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"c": "d", "e": "f", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster6"),
 				Labels: &eks.UpdateLabelsPayload{
@@ -111,8 +111,8 @@ func TestGetNodegroupConfigUpdate(t *testing.T) {
 		{
 			// test case where label should be updated
 			clusterName: "testcluster7",
-			ng1:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
-			ng2:         v1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "i"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng1:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "h"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
+			ng2:         eksv1.NodeGroup{Labels: aws.StringMap(map[string]string{"a": "b", "g": "i"}), MinSize: aws.Int64(1), MaxSize: aws.Int64(1)},
 			expectedNgUpdateInput: eks.UpdateNodegroupConfigInput{
 				ClusterName: aws.String("testcluster7"),
 				Labels: &eks.UpdateLabelsPayload{

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"os"
 
-	v12 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
+	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
 	_ "github.com/rancher/wrangler-api/pkg/generated/controllers/apiextensions.k8s.io"
 	controllergen "github.com/rancher/wrangler/pkg/controller-gen"
 	"github.com/rancher/wrangler/pkg/controller-gen/args"
 	"github.com/rancher/wrangler/pkg/crd"
 	"github.com/rancher/wrangler/pkg/yaml"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -33,9 +33,9 @@ func main() {
 			// In this controller we will use wrangler-api for apps api group
 			"": {
 				Types: []interface{}{
-					v1.Pod{},
-					v1.Node{},
-					v1.Secret{},
+					corev1.Pod{},
+					corev1.Node{},
+					corev1.Secret{},
 				},
 				InformersPackage: "k8s.io/client-go/informers",
 				ClientSetPackage: "k8s.io/client-go/kubernetes",
@@ -44,7 +44,7 @@ func main() {
 		},
 	})
 
-	eksClusterConfig := newCRD(&v12.EKSClusterConfig{}, func(c crd.CRD) crd.CRD {
+	eksClusterConfig := newCRD(&eksv1.EKSClusterConfig{}, func(c crd.CRD) crd.CRD {
 		c.ShortNames = []string{"ekscc"}
 		return c
 	})

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -123,7 +123,7 @@ func substituteVersions(config *E2EConfig) error {
 		return config.CertManagerVersion
 	})
 	if err != nil {
-		return fmt.Errorf("failed to substiture cert manager chart url: %w", err)
+		return fmt.Errorf("failed to substitute cert manager chart url: %w", err)
 	}
 	config.CertManagerChartURL = certManagerURL
 
@@ -131,7 +131,7 @@ func substituteVersions(config *E2EConfig) error {
 		return config.RancherVersion
 	})
 	if err != nil {
-		return fmt.Errorf("failed to substiture rancher chart url: %w", err)
+		return fmt.Errorf("failed to substitute rancher chart url: %w", err)
 	}
 	config.RancherChartURL = rancherURL
 


### PR DESCRIPTION
This PR:

- Enables more linters in the .golangci.yaml to have a better aligned package import aliases
- Fixes all lint errors as a consequence of newly added linters