### PR TITLE
Bring back functions that are used in rancher

### DIFF
--- a/controller/errors.go
+++ b/controller/errors.go
@@ -40,11 +40,3 @@ func notFound(err error) bool {
 
 	return false
 }
-
-// NodeGroupIssueIsUpdatable checks to see the node group can be updated with the given issue code.
-func NodeGroupIssueIsUpdatable(code string) bool {
-	return code == eks.NodegroupIssueCodeAsgInstanceLaunchFailures ||
-		code == eks.NodegroupIssueCodeInstanceLimitExceeded ||
-		code == eks.NodegroupIssueCodeInsufficientFreeAddresses ||
-		code == eks.NodegroupIssueCodeClusterUnreachable
-}

--- a/controller/external.go
+++ b/controller/external.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/eks"
+	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
+	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+)
+
+// StartAWSSessions starts AWS sessions.
+func StartAWSSessions(secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (*session.Session, *eks.EKS, error) {
+	sess, err := newAWSSession(secretsCache, spec)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting new aws session: %v", err)
+	}
+	return sess, eks.New(sess), nil
+}
+
+// NodeGroupIssueIsUpdatable checks to see the node group can be updated with the given issue code.
+func NodeGroupIssueIsUpdatable(code string) bool {
+	return code == eks.NodegroupIssueCodeAsgInstanceLaunchFailures ||
+		code == eks.NodegroupIssueCodeInstanceLimitExceeded ||
+		code == eks.NodegroupIssueCodeInsufficientFreeAddresses ||
+		code == eks.NodegroupIssueCodeClusterUnreachable
+}


### PR DESCRIPTION
Some functions are used in rancher/rancher so they have to be public. We added API diff workflow to make sure that it won't happen again.