### PR TITLE
📖  Clarify a bit more tagging a release in root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,31 @@ A KEv2 operator should be released if
 
 #### How do I release?
 
-Tag the latest commit on the `master` branch. For example, if latest tag is `v1.1.6-rc1` you would tag `v1.1.6-rc2`.
+Tag the latest commit on the `master` branch. For example, if latest tag is:
+* `v1.1.6-rc1` you should tag `v1.1.6-rc2`.
+* `v1.1.6` you should tag `v1.1.7-rc1`.
 
-    git pull upstream master --tags     // get the latest upstream changes (not your fork)
-    git tag v1.0.8-rc2                  // tag HEAD
-    git push upstream v1.0.8-rc2        // push the tag
+```bash
+# Get the latest upstream changes
+# Note: `upstream` must be the remote pointing to `git@github.com:rancher/eks-operator.git`.
+git pull upstream master --tags
+
+# Export the tag of the release to be cut, e.g.:
+export RELEASE_TAG=v1.1.6-rc2
+
+# Create tags locally
+git tag -s -a ${RELEASE_TAG} -m ${RELEASE_TAG}
+
+# Push tags
+# Note: `upstream` must be the remote pointing to `git@github.com:rancher/eks-operator.git`.
+git push upstream ${RELEASE_TAG}
+```
 
 Submit a [rancher/charts PR](https://github.com/rancher/charts/pull/2242) to update the operator and operator-crd chart versions.
 Submit a [rancher/rancher PR](https://github.com/rancher/rancher/pull/39745) to update the bundled chart.
 
 #### How do I unRC?
 
-UnRC is the process of removing the rc from a KEv2 operator tag and means the released version is stable and ready for use. Release the KEv2 operator but instead of bumping the rc, remove the rc. For example, if the latest release of EKS operator is `v1.1.6-rc1`, release the next version without the rc which would be `v1.1.7`.
+UnRC is the process of removing the rc from a KEv2 operator tag and means the released version is stable and ready for use. Release the KEv2 operator but instead of bumping the rc, remove the rc. For example, if the latest release of EKS operator is:
+* `v1.1.6-rc1`, release the next version without the rc which would be `v1.1.6`.
+* `v1.1.6`, that has no rc so release that version or `v1.1.7` if updates are available.


### PR DESCRIPTION
- When releasing unRC'ed version of the operator, the version should stay the same and not bump to a new minor version
- some minor improvement on notes related to tagging (with signature and annotation)