### PR TITLE
Out of tree EBS CSI Driver

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,3 +85,11 @@ issues:
     - revive
     text: "var-naming: don't use an underscore in package name"
     path: 'mock(\w+)/doc.go$'
+  - path: 'pkg/eks/create.go$'
+    text: "weak cryptographic primitive"
+    linters:
+      - gosec
+  - path: 'pkg/eks/create.go$'
+    text: "TLS InsecureSkipVerify set true."
+    linters:
+      - gosec

--- a/charts/eks-operator-crd/templates/crds.yaml
+++ b/charts/eks-operator-crd/templates/crds.yaml
@@ -27,6 +27,9 @@ spec:
               displayName:
                 nullable: true
                 type: string
+              ebsCSIDriver:
+                nullable: true
+                type: boolean
               imported:
                 type: boolean
               kmsKey:

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -447,22 +447,6 @@ func (h *Handler) create(config *eksv1.EKSClusterConfig, awsSVCs *awsServices) (
 		}
 	}
 
-	if aws.BoolValue(config.Spec.EBSCSIDriver) {
-		logrus.Infof("EBSCSIDriver is set to true: %v", config.Spec.EBSCSIDriver)
-		ebsCSIDriverInput := awsservices.EnableEBSCSIDriverInput{
-			EKSService: awsSVCs.eks,
-			IAMService: awsSVCs.iam,
-			CFService:  awsSVCs.cloudformation,
-			Config:     config,
-			// TODO: make this configurable?
-			AddonVersion: "latest",
-		}
-		err := awsservices.EnableEBSCSIDriver(ebsCSIDriverInput)
-		if err != nil {
-			return config, fmt.Errorf("error enabling EBS CSI driver: %w", err)
-		}
-	}
-
 	// If a user edits a cluster at the exact right (or wrong) time, then the
 	// `UpdateStatus` call may produce a conflict and will error. When the
 	// controller re-enters the create function, it will try to verify that a
@@ -1263,7 +1247,7 @@ func (h *Handler) updateUpstreamClusterState(upstreamSpec *eksv1.EKSClusterConfi
 				Config:       config,
 				AddonVersion: "latest",
 			}
-			if err := awsservices.EnableEBSCSIDriver(ebsCSIDriverInput); err != nil {
+			if err := awsservices.EnableEBSCSIDriver(&ebsCSIDriverInput); err != nil {
 				return config, fmt.Errorf("error enabling ebs csi driver addon: %w", err)
 			}
 		}

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -443,16 +443,20 @@ func (h *Handler) create(config *eksv1.EKSClusterConfig, awsSVCs *awsServices) (
 		}
 	}
 
-	// Test new boolean option for enabling EBS CSI driver
 	if aws.BoolValue(config.Spec.EBSCSIDriver) {
 		logrus.Infof("EBSCSIDriver is set to true: %v", config.Spec.EBSCSIDriver)
 		ebsCSIDriverInput := awsservices.EnableEBSCSIDriverInput{
-			EKSService: h.awsServices.eks,
-			IAMService: h.awsServices.iam,
-			CFService:  h.awsServices.cloudformation,
+			EKSService: awsSVCs.eks,
+			IAMService: awsSVCs.iam,
+			CFService:  awsSVCs.cloudformation,
 			Config:     config,
+			// TODO: make this configurable?
+			AddonVersion: "latest",
 		}
-		awsservices.EnableEBSCSIDriver(ebsCSIDriverInput)
+		err := awsservices.EnableEBSCSIDriver(ebsCSIDriverInput)
+		if err != nil {
+			return config, fmt.Errorf("error enabling EBS CSI driver: %w", err)
+		}
 	}
 
 	// If a user edits a cluster at the exact right (or wrong) time, then the

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -446,7 +446,13 @@ func (h *Handler) create(config *eksv1.EKSClusterConfig, awsSVCs *awsServices) (
 	// Test new boolean option for enabling EBS CSI driver
 	if aws.BoolValue(config.Spec.EBSCSIDriver) {
 		logrus.Infof("EBSCSIDriver is set to true: %v", config.Spec.EBSCSIDriver)
-		//awsservices.CreateOIDCProvider(config, h.awsServices.iam)
+		ebsCSIDriverInput := awsservices.EnableEBSCSIDriverInput{
+			EKSService: h.awsServices.eks,
+			IAMService: h.awsServices.iam,
+			CFService:  h.awsServices.cloudformation,
+			Config:     config,
+		}
+		awsservices.EnableEBSCSIDriver(ebsCSIDriverInput)
 	}
 
 	// If a user edits a cluster at the exact right (or wrong) time, then the

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -443,6 +443,12 @@ func (h *Handler) create(config *eksv1.EKSClusterConfig, awsSVCs *awsServices) (
 		}
 	}
 
+	// Test new boolean option for enabling EBS CSI driver
+	if aws.BoolValue(config.Spec.EBSCSIDriver) {
+		logrus.Infof("EBSCSIDriver is set to true: %v", config.Spec.EBSCSIDriver)
+		//awsservices.CreateOIDCProvider(config, h.awsServices.iam)
+	}
+
 	// If a user edits a cluster at the exact right (or wrong) time, then the
 	// `UpdateStatus` call may produce a conflict and will error. When the
 	// controller re-enters the create function, it will try to verify that a

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -43,6 +43,7 @@ type EKSClusterConfigSpec struct {
 	KmsKey                 *string           `json:"kmsKey" norman:"noupdate,pointer"`
 	PublicAccess           *bool             `json:"publicAccess"`
 	PrivateAccess          *bool             `json:"privateAccess"`
+	EBSCSIDriver           *bool             `json:"ebsCSIDriver"`
 	PublicAccessSources    []string          `json:"publicAccessSources"`
 	LoggingTypes           []string          `json:"loggingTypes"`
 	Subnets                []string          `json:"subnets" norman:"noupdate"`

--- a/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
@@ -121,6 +121,11 @@ func (in *EKSClusterConfigSpec) DeepCopyInto(out *EKSClusterConfigSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EBSCSIDriver != nil {
+		in, out := &in.EBSCSIDriver, &out.EBSCSIDriver
+		*out = new(bool)
+		**out = **in
+	}
 	if in.PublicAccessSources != nil {
 		in, out := &in.PublicAccessSources, &out.PublicAccessSources
 		*out = make([]string, len(*in))

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -486,7 +486,7 @@ type EnableEBSCSIDriverInput struct {
 
 // EnableEBSCSIDriver manages the installation of the EBS CSI driver for EKS, including the
 // creation of the OIDC Provider, the IAM role and the validation and installation of the EKS add-on
-func EnableEBSCSIDriver(opts EnableEBSCSIDriverInput) error {
+func EnableEBSCSIDriver(opts *EnableEBSCSIDriverInput) error {
 	oidcID, err := configureOIDCProvider(opts.IAMService, opts.EKSService, opts.Config)
 	if err != nil {
 		return fmt.Errorf("could not configure oidc provider: %w", err)

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -1,11 +1,14 @@
 package eks
 
 import (
+	"bytes"
 	"crypto/sha1"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"html/template"
+	"log"
 	"net/http"
 	"net/url"
 	"path"
@@ -39,6 +42,7 @@ const (
 	defaultStorageDeviceName = "/dev/xvda"
 
 	defaultAudienceOpenIDConnect = "sts.amazonaws.com"
+	ebsCSIAddonName              = "aws-ebs-csi-driver"
 )
 
 type CreateClusterOptions struct {
@@ -314,7 +318,11 @@ func CreateNodeGroup(opts *CreateNodeGroupOptions) (string, string, error) {
 	return aws.StringValue(launchTemplateVersion), generatedNodeRole, err
 }
 
-func CreateNewLaunchTemplateVersion(ec2Service services.EC2ServiceInterface, launchTemplateID string, group eksv1.NodeGroup) (*eksv1.LaunchTemplate, error) {
+func CreateNewLaunchTemplateVersion(
+	ec2Service services.EC2ServiceInterface,
+	launchTemplateID string,
+	group eksv1.NodeGroup,
+) (*eksv1.LaunchTemplate, error) {
 	launchTemplate, err := buildLaunchTemplateData(ec2Service, group)
 	if err != nil {
 		return nil, err
@@ -337,7 +345,10 @@ func CreateNewLaunchTemplateVersion(ec2Service services.EC2ServiceInterface, lau
 	}, nil
 }
 
-func buildLaunchTemplateData(ec2Service services.EC2ServiceInterface, group eksv1.NodeGroup) (*ec2.RequestLaunchTemplateData, error) {
+func buildLaunchTemplateData(
+	ec2Service services.EC2ServiceInterface,
+	group eksv1.NodeGroup,
+) (*ec2.RequestLaunchTemplateData, error) {
 	var imageID *string
 	if aws.StringValue(group.ImageID) != "" {
 		imageID = group.ImageID
@@ -346,7 +357,10 @@ func buildLaunchTemplateData(ec2Service services.EC2ServiceInterface, group eksv
 	userdata := group.UserData
 	if aws.StringValue(userdata) != "" {
 		if !strings.Contains(*userdata, "Content-Type: multipart/mixed") {
-			return nil, fmt.Errorf("userdata for nodegroup [%s] is not of mime time multipart/mixed", aws.StringValue(group.NodegroupName))
+			return nil, fmt.Errorf(
+				"userdata for nodegroup [%s] is not of mime time multipart/mixed",
+				aws.StringValue(group.NodegroupName),
+			)
 		}
 		*userdata = base64.StdEncoding.EncodeToString([]byte(*userdata))
 	}
@@ -472,20 +486,38 @@ func getParameterValueFromOutput(key string, outputs []*cloudformation.Output) s
 	return ""
 }
 
+// EnableEBSCSIDriverInput holds the options for installing the EBS CSI driver
+type EnableEBSCSIDriverInput struct {
+	EKSService     services.EKSServiceInterface
+	IAMService     services.IAMServiceInterface
+	CFService      services.CloudFormationServiceInterface
+	Config         *eksv1.EKSClusterConfig
+	OIDCProviderID string
+	DriverRoleARN  string
+}
+
+// EnableEBSCSIDriver manages the EBS CSI driver installation, including the creation of the OIDC Provider,
+// the IAM role and the validation and installation of the EKS add-on
+func EnableEBSCSIDriver(opts EnableEBSCSIDriverInput) {}
+
 // ConfigureOIDCProvider creates a new Open ID Connect Provider associated with the cluster
 // if there are no providers available
-func ConfigureOIDCProvider(config *eksv1.EKSClusterConfig, iamService services.IAMServiceInterface, eksService services.EKSServiceInterface) error {
-	output, err := iamService.ListOIDCProviders(&iam.ListOpenIDConnectProvidersInput{})
+// func ConfigureOIDCProvider(config *eksv1.EKSClusterConfig, iamService services.IAMServiceInterface, eksService services.EKSServiceInterface) error {
+func ConfigureOIDCProvider(opts EnableEBSCSIDriverInput) error {
+	output, err := opts.IAMService.ListOIDCProviders(&iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {
 		return fmt.Errorf("error listing oidc providers: %v", err)
 	}
-	clusterOutput, err := eksService.DescribeCluster(&eks.DescribeClusterInput{
-		Name: aws.String(config.Spec.DisplayName),
+	clusterOutput, err := opts.EKSService.DescribeCluster(&eks.DescribeClusterInput{
+		Name: aws.String(opts.Config.Spec.DisplayName),
 	})
 	id := path.Base(*clusterOutput.Cluster.Identity.Oidc.Issuer)
 
 	for _, prov := range output.OpenIDConnectProviderList {
 		if strings.Contains(*prov.Arn, id) {
+			// TODO: review this and how to proceed with creation of OIDC provider
+			// how to pass the OIDC provider ID to the EBS CSI driver?
+			opts.OIDCProviderID = path.Base(*prov.Arn)
 			return nil
 		}
 	}
@@ -500,7 +532,7 @@ func ConfigureOIDCProvider(config *eksv1.EKSClusterConfig, iamService services.I
 		Url:            clusterOutput.Cluster.Identity.Oidc.Issuer,
 		Tags:           []*iam.Tag{},
 	}
-	_, err = iamService.CreateOIDCProvider(input)
+	_, err = opts.IAMService.CreateOIDCProvider(input)
 	if err != nil {
 		return fmt.Errorf("creating OIDC provider: %v", err)
 	}
@@ -539,4 +571,81 @@ func getIssuerThumbprint(issuer string) (string, error) {
 	root := resp.TLS.PeerCertificates[len(resp.TLS.PeerCertificates)-1]
 
 	return fmt.Sprintf("%x", sha1.Sum(root.Raw)), nil
+}
+
+// CreateEBSCSIDriverRole creates an IAM role for the EKS cluster to interact with
+// EBS through the previously created Open ID Connect provider
+func CreateEBSCSIDriverRole(opts EnableEBSCSIDriverInput) (string, error) {
+	templateData := struct {
+		Region     string
+		ProviderID string
+	}{
+		Region:     opts.Config.Spec.Region,
+		ProviderID: opts.OIDCProviderID,
+	}
+	tmpl, err := template.New("ebsrole").Parse(templates.EBSCSIDriverTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parsing ebs role template: %v", err)
+	}
+	buf := &bytes.Buffer{}
+	if execErr := tmpl.Execute(buf, templateData); execErr != nil {
+		return "", fmt.Errorf("executing ebs role template: %v", err)
+	}
+	finalTemplate := buf.String()
+
+	output, err := CreateStack(CreateStackOptions{
+		CloudFormationService: opts.CFService,
+		StackName:             fmt.Sprintf("%s-ebs-csi-driver-role", opts.Config.Spec.DisplayName),
+		DisplayName:           opts.Config.Spec.DisplayName,
+		TemplateBody:          finalTemplate,
+		Capabilities:          []string{cloudformation.CapabilityCapabilityIam},
+		Parameters:            []*cloudformation.Parameter{},
+	})
+	if err != nil {
+		// If there was an error creating the driver role stack, return an empty role arn and the error
+		return "", fmt.Errorf("creating ebs csi driver role: %v", err)
+	}
+	createdRoleArn := getParameterValueFromOutput("EBSCSIDriverRole", output.Stacks[0].Outputs)
+
+	return createdRoleArn, nil
+}
+
+func checkEBSAddon(opts EnableEBSCSIDriverInput) (string, error) {
+	input := eks.DescribeAddonInput{
+		AddonName:   aws.String(ebsCSIAddonName),
+		ClusterName: aws.String(opts.Config.Spec.DisplayName),
+	}
+
+	output, err := opts.EKSService.DescribeAddon(&input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == eks.ErrCodeResourceNotFoundException {
+				log.Println("EBS CSI driver addon not found: got resource not found exception")
+				return "", nil
+			}
+		}
+	}
+	if output == nil {
+		log.Println("EBS CSI driver addon not found")
+		return "", nil
+	}
+	log.Println("EBS CSI driver addon found:", *output.Addon.AddonArn)
+
+	return *output.Addon.AddonArn, nil
+}
+
+func installEBSAddon(opts EnableEBSCSIDriverInput) error {
+	input := eks.CreateAddonInput{
+		AddonName:             aws.String(ebsCSIAddonName),
+		ClusterName:           aws.String(opts.Config.Spec.DisplayName),
+		ServiceAccountRoleArn: aws.String(opts.DriverRoleARN),
+	}
+
+	output, err := opts.EKSService.CreateAddon(&input)
+	if err != nil {
+		return fmt.Errorf("cannot install EBS CSI driver addon: %v", err)
+	}
+	fmt.Println("installed addon EBS CSI driver:", *output.Addon.AddonArn)
+
+	return nil
 }

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -1143,7 +1143,7 @@ var _ = Describe("installEBSCSIDriver", func() {
 			},
 		}
 		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(eksDescribeAddonOutput, nil)
-		addonArn, err := checkEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		addonArn, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).To(Succeed())
 		Expect(addonArn).To(Equal("arn:aws::ebs-csi-driver"))
 	})
@@ -1151,7 +1151,7 @@ var _ = Describe("installEBSCSIDriver", func() {
 	It("should detect that addon is not installed", func() {
 		eksDescribeAddonOutput = &eks.DescribeAddonOutput{}
 		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(eksDescribeAddonOutput, nil)
-		addonArn, err := checkEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		addonArn, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).To(Succeed())
 		Expect(addonArn).To(Equal(""))
 	})
@@ -1159,7 +1159,7 @@ var _ = Describe("installEBSCSIDriver", func() {
 	It("should fail to check if addon is not installed", func() {
 		eksDescribeAddonOutput = &eks.DescribeAddonOutput{}
 		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(nil, fmt.Errorf("failed to describe addon"))
-		_, err := checkEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		_, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).ToNot(Succeed())
 	})
 

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -137,16 +137,16 @@ var _ = Describe("newClusterInput", func() {
 
 var _ = Describe("CreateStack", func() {
 	var (
-		mockController             *gomock.Controller
-		cloudFormationsServiceMock *mock_services.MockCloudFormationServiceInterface
-		stackCreationOptions       *CreateStackOptions
+		mockController            *gomock.Controller
+		cloudFormationServiceMock *mock_services.MockCloudFormationServiceInterface
+		stackCreationOptions      *CreateStackOptions
 	)
 
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
-		cloudFormationsServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
+		cloudFormationServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
 		stackCreationOptions = &CreateStackOptions{
-			CloudFormationService: cloudFormationsServiceMock,
+			CloudFormationService: cloudFormationServiceMock,
 			StackName:             "test",
 			DisplayName:           "test",
 			TemplateBody:          "test-body",
@@ -160,7 +160,7 @@ var _ = Describe("CreateStack", func() {
 	})
 
 	It("should successfully create a stack", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(&cloudformation.CreateStackInput{
+		cloudFormationServiceMock.EXPECT().CreateStack(&cloudformation.CreateStackInput{
 			StackName:    &stackCreationOptions.StackName,
 			TemplateBody: &stackCreationOptions.TemplateBody,
 			Capabilities: aws.StringSlice(stackCreationOptions.Capabilities),
@@ -173,7 +173,7 @@ var _ = Describe("CreateStack", func() {
 			},
 		}).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(
 			&cloudformation.DescribeStacksInput{
 				StackName: &stackCreationOptions.StackName,
 			},
@@ -193,16 +193,16 @@ var _ = Describe("CreateStack", func() {
 	})
 
 	It("should fail to create a stack if CreateStack returns error", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, errors.New("error"))
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, errors.New("error"))
 
 		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail to create a stack if DescribeStacks returns no stacks", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(
 			&cloudformation.DescribeStacksInput{
 				StackName: &stackCreationOptions.StackName,
 			},
@@ -213,8 +213,8 @@ var _ = Describe("CreateStack", func() {
 	})
 
 	It("should fail to create a stack if stack already exists", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, awserr.New(cloudformation.ErrCodeAlreadyExistsException, "", nil))
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, awserr.New(cloudformation.ErrCodeAlreadyExistsException, "", nil))
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -228,16 +228,16 @@ var _ = Describe("CreateStack", func() {
 	})
 
 	It("should fail to create a stack if DescribeStack return errors", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(nil, errors.New("error"))
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(nil, errors.New("error"))
 
 		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail to create a stack if stack status is CREATE_FAILED", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -245,7 +245,7 @@ var _ = Describe("CreateStack", func() {
 					},
 				},
 			}, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStackEvents(
+		cloudFormationServiceMock.EXPECT().DescribeStackEvents(
 			&cloudformation.DescribeStackEventsInput{
 				StackName: &stackCreationOptions.StackName,
 			},
@@ -266,8 +266,8 @@ var _ = Describe("CreateStack", func() {
 	})
 
 	It("should fail to create a stack if stack status is ROLLBACK_IN_PROGRESS", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -275,7 +275,7 @@ var _ = Describe("CreateStack", func() {
 					},
 				},
 			}, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStackEvents(
+		cloudFormationServiceMock.EXPECT().DescribeStackEvents(
 			&cloudformation.DescribeStackEventsInput{
 				StackName: &stackCreationOptions.StackName,
 			},
@@ -618,22 +618,22 @@ var _ = Describe("createNewLaunchTemplateVersion", func() {
 
 var _ = Describe("CreateNodeGroup", func() {
 	var (
-		mockController             *gomock.Controller
-		eksServiceMock             *mock_services.MockEKSServiceInterface
-		ec2ServiceMock             *mock_services.MockEC2ServiceInterface
-		cloudFormationsServiceMock *mock_services.MockCloudFormationServiceInterface
-		createNodeGroupOpts        *CreateNodeGroupOptions
+		mockController            *gomock.Controller
+		eksServiceMock            *mock_services.MockEKSServiceInterface
+		ec2ServiceMock            *mock_services.MockEC2ServiceInterface
+		cloudFormationServiceMock *mock_services.MockCloudFormationServiceInterface
+		createNodeGroupOpts       *CreateNodeGroupOptions
 	)
 
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		eksServiceMock = mock_services.NewMockEKSServiceInterface(mockController)
 		ec2ServiceMock = mock_services.NewMockEC2ServiceInterface(mockController)
-		cloudFormationsServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
+		cloudFormationServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
 		createNodeGroupOpts = &CreateNodeGroupOptions{
 			EC2Service:            ec2ServiceMock,
 			EKSService:            eksServiceMock,
-			CloudFormationService: cloudFormationsServiceMock,
+			CloudFormationService: cloudFormationServiceMock,
 
 			Config: &eksv1.EKSClusterConfig{
 				Spec: eksv1.EKSClusterConfigSpec{
@@ -694,9 +694,9 @@ var _ = Describe("CreateNodeGroup", func() {
 			},
 		}, nil)
 
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -744,9 +744,9 @@ var _ = Describe("CreateNodeGroup", func() {
 			Name:    aws.String("test"),
 		}
 
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -812,8 +812,8 @@ var _ = Describe("CreateNodeGroup", func() {
 				},
 			},
 		}, nil)
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -871,9 +871,9 @@ var _ = Describe("CreateNodeGroup", func() {
 			},
 		}, nil)
 
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -926,9 +926,9 @@ var _ = Describe("CreateNodeGroup", func() {
 			},
 		}, nil)
 
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -980,9 +980,9 @@ var _ = Describe("CreateNodeGroup", func() {
 			},
 		}, nil)
 
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -1027,28 +1027,27 @@ var _ = Describe("CreateNodeGroup", func() {
 
 var _ = Describe("installEBSCSIDriver", func() {
 	var (
-		mockController             *gomock.Controller
-		eksServiceMock             *mock_services.MockEKSServiceInterface
-		iamServiceMock             *mock_services.MockIAMServiceInterface
-		cloudFormationsServiceMock *mock_services.MockCloudFormationServiceInterface
-		enableEBSCSIDriverInput    *EnableEBSCSIDriverInput
-		oidcListProvidersOutput    *iam.ListOpenIDConnectProvidersOutput
-		oidcCreateProviderOutput   *iam.CreateOpenIDConnectProviderOutput
-		eksClusterOutput           *eks.DescribeClusterOutput
-		eksDescribeAddonOutput     *eks.DescribeAddonOutput
-		eksCreateAddonOutput       *eks.CreateAddonOutput
-		defaultAWSRegion           string
+		mockController            *gomock.Controller
+		eksServiceMock            *mock_services.MockEKSServiceInterface
+		iamServiceMock            *mock_services.MockIAMServiceInterface
+		cloudFormationServiceMock *mock_services.MockCloudFormationServiceInterface
+		enableEBSCSIDriverInput   *EnableEBSCSIDriverInput
+		oidcListProvidersOutput   *iam.ListOpenIDConnectProvidersOutput
+		oidcCreateProviderOutput  *iam.CreateOpenIDConnectProviderOutput
+		eksClusterOutput          *eks.DescribeClusterOutput
+		eksCreateAddonOutput      *eks.CreateAddonOutput
+		defaultAWSRegion          string
 	)
 
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		eksServiceMock = mock_services.NewMockEKSServiceInterface(mockController)
 		iamServiceMock = mock_services.NewMockIAMServiceInterface(mockController)
-		cloudFormationsServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
+		cloudFormationServiceMock = mock_services.NewMockCloudFormationServiceInterface(mockController)
 		enableEBSCSIDriverInput = &EnableEBSCSIDriverInput{
 			EKSService: eksServiceMock,
 			IAMService: iamServiceMock,
-			CFService:  cloudFormationsServiceMock,
+			CFService:  cloudFormationServiceMock,
 			Config:     &eksv1.EKSClusterConfig{},
 		}
 		defaultAWSRegion = "us-east-1" // must use a default region to get OIDC thumbprint
@@ -1110,8 +1109,8 @@ var _ = Describe("installEBSCSIDriver", func() {
 	})
 
 	It("should successfully create driver iam role", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
 			&cloudformation.DescribeStacksOutput{
 				Stacks: []*cloudformation.Stack{
 					{
@@ -1130,36 +1129,9 @@ var _ = Describe("installEBSCSIDriver", func() {
 	})
 
 	It("should fail to create driver iam role", func() {
-		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
-		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(nil, fmt.Errorf("failed to describe stack"))
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(nil, fmt.Errorf("failed to describe stack"))
 		_, err := createEBSCSIDriverRole(enableEBSCSIDriverInput.CFService, enableEBSCSIDriverInput.Config, "")
-		Expect(err).ToNot(Succeed())
-	})
-
-	It("should detect that addon is already installed", func() {
-		eksDescribeAddonOutput = &eks.DescribeAddonOutput{
-			Addon: &eks.Addon{
-				AddonArn: aws.String("arn:aws::ebs-csi-driver"),
-			},
-		}
-		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(eksDescribeAddonOutput, nil)
-		addonArn, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
-		Expect(err).To(Succeed())
-		Expect(addonArn).To(Equal("arn:aws::ebs-csi-driver"))
-	})
-
-	It("should detect that addon is not installed", func() {
-		eksDescribeAddonOutput = &eks.DescribeAddonOutput{}
-		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(eksDescribeAddonOutput, nil)
-		addonArn, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
-		Expect(err).To(Succeed())
-		Expect(addonArn).To(Equal(""))
-	})
-
-	It("should fail to check if addon is not installed", func() {
-		eksDescribeAddonOutput = &eks.DescribeAddonOutput{}
-		eksServiceMock.EXPECT().DescribeAddon(gomock.Any()).Return(nil, fmt.Errorf("failed to describe addon"))
-		_, err := CheckEBSAddon(enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).ToNot(Succeed())
 	})
 

--- a/pkg/eks/services/eks.go
+++ b/pkg/eks/services/eks.go
@@ -20,6 +20,8 @@ type EKSServiceInterface interface {
 	UpdateNodegroupVersion(input *eks.UpdateNodegroupVersionInput) (*eks.UpdateNodegroupVersionOutput, error)
 	TagResource(input *eks.TagResourceInput) (*eks.TagResourceOutput, error)
 	UntagResource(input *eks.UntagResourceInput) (*eks.UntagResourceOutput, error)
+	CreateAddon(input *eks.CreateAddonInput) (*eks.CreateAddonOutput, error)
+	DescribeAddon(input *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error)
 }
 
 type eksService struct {
@@ -86,4 +88,12 @@ func (c *eksService) UntagResource(input *eks.UntagResourceInput) (*eks.UntagRes
 
 func (c *eksService) UpdateNodegroupVersion(input *eks.UpdateNodegroupVersionInput) (*eks.UpdateNodegroupVersionOutput, error) {
 	return c.svc.UpdateNodegroupVersion(input)
+}
+
+func (c *eksService) CreateAddon(input *eks.CreateAddonInput) (*eks.CreateAddonOutput, error) {
+	return c.svc.CreateAddon(input)
+}
+
+func (c *eksService) DescribeAddon(input *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error) {
+	return c.svc.DescribeAddon(input)
 }

--- a/pkg/eks/services/iam.go
+++ b/pkg/eks/services/iam.go
@@ -7,6 +7,8 @@ import (
 
 type IAMServiceInterface interface {
 	GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error)
+	ListOIDCProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
+	CreateOIDCProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error)
 }
 
 type iamService struct {
@@ -21,4 +23,12 @@ func NewIAMService(sess *session.Session) IAMServiceInterface {
 
 func (c *iamService) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
 	return c.svc.GetRole(input)
+}
+
+func (c *iamService) ListOIDCProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return c.svc.ListOpenIDConnectProviders(input)
+}
+
+func (c *iamService) CreateOIDCProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	return c.svc.CreateOpenIDConnectProvider(input)
 }

--- a/pkg/eks/services/mock_services/eks_mock.go
+++ b/pkg/eks/services/mock_services/eks_mock.go
@@ -243,3 +243,33 @@ func (mr *MockEKSServiceInterfaceMockRecorder) UpdateNodegroupVersion(input inte
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodegroupVersion", reflect.TypeOf((*MockEKSServiceInterface)(nil).UpdateNodegroupVersion), input)
 }
+
+// CreateAddon mocks base method.
+func (m *MockEKSServiceInterface) CreateAddon(input *eks.CreateAddonInput) (*eks.CreateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAddon", input)
+	ret0, _ := ret[0].(*eks.CreateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAddon indicates an expected call of UpdateNodegroupVersion.
+func (mr *MockEKSServiceInterfaceMockRecorder) CreateAddon(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).CreateAddon), input)
+}
+
+// DescribeAddon mocks base method.
+func (m *MockEKSServiceInterface) DescribeAddon(input *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddon", input)
+	ret0, _ := ret[0].(*eks.DescribeAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddon indicates an expected call of UpdateNodegroupVersion.
+func (mr *MockEKSServiceInterfaceMockRecorder) DescribeAddon(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).DescribeAddon), input)
+}

--- a/pkg/eks/services/mock_services/eks_mock.go
+++ b/pkg/eks/services/mock_services/eks_mock.go
@@ -34,6 +34,21 @@ func (m *MockEKSServiceInterface) EXPECT() *MockEKSServiceInterfaceMockRecorder 
 	return m.recorder
 }
 
+// CreateAddon mocks base method.
+func (m *MockEKSServiceInterface) CreateAddon(input *eks.CreateAddonInput) (*eks.CreateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAddon", input)
+	ret0, _ := ret[0].(*eks.CreateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAddon indicates an expected call of CreateAddon.
+func (mr *MockEKSServiceInterfaceMockRecorder) CreateAddon(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).CreateAddon), input)
+}
+
 // CreateCluster mocks base method.
 func (m *MockEKSServiceInterface) CreateCluster(input *eks.CreateClusterInput) (*eks.CreateClusterOutput, error) {
 	m.ctrl.T.Helper()
@@ -92,6 +107,21 @@ func (m *MockEKSServiceInterface) DeleteNodegroup(input *eks.DeleteNodegroupInpu
 func (mr *MockEKSServiceInterfaceMockRecorder) DeleteNodegroup(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodegroup", reflect.TypeOf((*MockEKSServiceInterface)(nil).DeleteNodegroup), input)
+}
+
+// DescribeAddon mocks base method.
+func (m *MockEKSServiceInterface) DescribeAddon(input *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddon", input)
+	ret0, _ := ret[0].(*eks.DescribeAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddon indicates an expected call of DescribeAddon.
+func (mr *MockEKSServiceInterfaceMockRecorder) DescribeAddon(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).DescribeAddon), input)
 }
 
 // DescribeCluster mocks base method.
@@ -242,34 +272,4 @@ func (m *MockEKSServiceInterface) UpdateNodegroupVersion(input *eks.UpdateNodegr
 func (mr *MockEKSServiceInterfaceMockRecorder) UpdateNodegroupVersion(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodegroupVersion", reflect.TypeOf((*MockEKSServiceInterface)(nil).UpdateNodegroupVersion), input)
-}
-
-// CreateAddon mocks base method.
-func (m *MockEKSServiceInterface) CreateAddon(input *eks.CreateAddonInput) (*eks.CreateAddonOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAddon", input)
-	ret0, _ := ret[0].(*eks.CreateAddonOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateAddon indicates an expected call of UpdateNodegroupVersion.
-func (mr *MockEKSServiceInterfaceMockRecorder) CreateAddon(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).CreateAddon), input)
-}
-
-// DescribeAddon mocks base method.
-func (m *MockEKSServiceInterface) DescribeAddon(input *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DescribeAddon", input)
-	ret0, _ := ret[0].(*eks.DescribeAddonOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DescribeAddon indicates an expected call of UpdateNodegroupVersion.
-func (mr *MockEKSServiceInterfaceMockRecorder) DescribeAddon(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddon", reflect.TypeOf((*MockEKSServiceInterface)(nil).DescribeAddon), input)
 }

--- a/pkg/eks/services/mock_services/iam_mock.go
+++ b/pkg/eks/services/mock_services/iam_mock.go
@@ -48,3 +48,33 @@ func (mr *MockIAMServiceInterfaceMockRecorder) GetRole(input interface{}) *gomoc
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockIAMServiceInterface)(nil).GetRole), input)
 }
+
+// ListOIDCProviders mocks base method.
+func (m *MockIAMServiceInterface) ListOIDCProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOIDCProviders", input)
+	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOIDCProviders indicates an expected call of ListOIDCProviders.
+func (mr *MockIAMServiceInterfaceMockRecorder) ListOIDCProviders(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOIDCProviders", reflect.TypeOf((*MockIAMServiceInterface)(nil).ListOIDCProviders), input)
+}
+
+// CreateOIDCProvider mocks base method.
+func (m *MockIAMServiceInterface) CreateOIDCProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOIDCProvider", input)
+	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOIDCProvider indicates an expected call of CreateOIDCProvider.
+func (mr *MockIAMServiceInterfaceMockRecorder) CreateOIDCProvider(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOIDCProvider", reflect.TypeOf((*MockIAMServiceInterface)(nil).CreateOIDCProvider), input)
+}

--- a/pkg/eks/services/mock_services/iam_mock.go
+++ b/pkg/eks/services/mock_services/iam_mock.go
@@ -34,6 +34,21 @@ func (m *MockIAMServiceInterface) EXPECT() *MockIAMServiceInterfaceMockRecorder 
 	return m.recorder
 }
 
+// CreateOIDCProvider mocks base method.
+func (m *MockIAMServiceInterface) CreateOIDCProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOIDCProvider", input)
+	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOIDCProvider indicates an expected call of CreateOIDCProvider.
+func (mr *MockIAMServiceInterfaceMockRecorder) CreateOIDCProvider(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOIDCProvider", reflect.TypeOf((*MockIAMServiceInterface)(nil).CreateOIDCProvider), input)
+}
+
 // GetRole mocks base method.
 func (m *MockIAMServiceInterface) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
 	m.ctrl.T.Helper()
@@ -62,19 +77,4 @@ func (m *MockIAMServiceInterface) ListOIDCProviders(input *iam.ListOpenIDConnect
 func (mr *MockIAMServiceInterfaceMockRecorder) ListOIDCProviders(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOIDCProviders", reflect.TypeOf((*MockIAMServiceInterface)(nil).ListOIDCProviders), input)
-}
-
-// CreateOIDCProvider mocks base method.
-func (m *MockIAMServiceInterface) CreateOIDCProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOIDCProvider", input)
-	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateOIDCProvider indicates an expected call of CreateOIDCProvider.
-func (mr *MockIAMServiceInterfaceMockRecorder) CreateOIDCProvider(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOIDCProvider", reflect.TypeOf((*MockIAMServiceInterface)(nil).CreateOIDCProvider), input)
 }

--- a/templates/template.go
+++ b/templates/template.go
@@ -257,4 +257,36 @@ Outputs:
       Name: !Sub "${AWS::StackName}-RoleArn"
 
 `
+	EBSCSIDriverTemplate = `---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Amazon EKS EBS CSI Driver Role'
+
+
+Resources:
+
+  AWSEBSCSIDriverRoleForAmazonEKS:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Federated:
+			- !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/oidc.eks.${AWS::Region}.amazonaws.com/id/${OIDCProvider}"
+          Action: sts:AssumeRoleWithWebIdentity
+		  Condition:
+		    StringEquals:
+			- !Sub "oidc.eks.${AWS::Region}.amazonaws.com/id/${OIDCProvider}:aud": "sts.amazonaws.com",
+			- !Sub "oidc.eks.${AWS::Region}.amazonaws.com/id/${OIDCProvider}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+
+Outputs:
+
+  RoleArn:
+    Description: The role that EKS will for enabling the EBS CSI driver
+    Value: !GetAtt AWSEBSCSIDriverRoleForAmazonEKS.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleArn"
+
+`
 )

--- a/templates/template.go
+++ b/templates/template.go
@@ -280,7 +280,7 @@ Resources:
         - Effect: Allow
           Principal:
             Federated:
-            - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/oidc.eks.{.Region}.amazonaws.com/id/{.ProviderID}"
+            - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/oidc.eks.{{.Region}}.amazonaws.com/id/{{.ProviderID}}"
           Action: sts:AssumeRoleWithWebIdentity
           Condition:
             StringEquals: {


### PR DESCRIPTION
Issue #106 

## Problem

With EKS v1.23 and higher it requires the use of the out of tree EBS CSI driver. If this isn't available then and PVC will not be bound and pods using the volumes will stay in pending.

This is a problem for creating new clusters and for upgrading clusters from 1.22

## Solution

The solution is based on the support utility rancherlabs/support-tools#217 which has been used as a workaround while the functionality is added to the operator.

- A boolean field is added to `EKSClusterConfigSpec` [EBSCSIDriver](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/pkg/apis/eks.cattle.io/v1/types.go#L46). This will require to update the EKS create cluster UI to have an option to set this new spec. 
- If set to true, the EBS CSI driver for EKS will be installed after the cluster is created.

### Installation procedure
- [Create OIDC provider for the cluster](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/pkg/eks/create.go#L530). This requires obtaining the thumbprint for the provider, which is a SHA1 of the certificate [see notes](#Notes).
- [Create IAM role](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/pkg/eks/create.go#L600) with the managed policy `AmazonEBSCSIDriverPolicy` which grants permissions to interact with EBS. The role allows `AssumeRoleWithWebIdentity` to the OIDC provider. (optionally) In the UI we can also warn the user that additional permissions are required. This role is created as a new [CloudFormation stack](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/templates/template.go#L260) `<cluster-name>-ebs-csi-driver-role`.
- [Install EBS add-on](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/pkg/eks/create.go#L634)

The cluster can be updated to install the add-on after it is created.

## Notes
- `golangci` prevents from using SHA1 for being a "weak cryptographic primitive", which required to add an [exclude rule].(https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/.golangci.yml#L89) 
- The CloudFormation stack that creates the driver role is [configured to be removed](https://github.com/salasberryfin/eks-operator/blob/46750b97cb4bb45019825cb2a90536bceca46854/controller/eks-cluster-config-handler.go#L251) as other stacks associated with the cluster.
- Extra permissions need to be added to the IAM role if the user encrypts EBS volumes with a custom KMS key.
- Tests (and mocks) have been added for the new functionality.