### PR TITLE
Fix AWS clients initialization

### DIFF
--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -38,7 +38,7 @@ type CreateClusterOptions struct {
 	RoleARN    string
 }
 
-func CreateCluster(opts CreateClusterOptions) error {
+func CreateCluster(opts *CreateClusterOptions) error {
 	createClusterInput := newClusterInput(opts.Config, opts.RoleARN)
 
 	_, err := opts.EKSService.CreateCluster(createClusterInput)
@@ -84,7 +84,7 @@ type CreateStackOptions struct {
 	Parameters            []*cloudformation.Parameter
 }
 
-func CreateStack(opts CreateStackOptions) (*cloudformation.DescribeStacksOutput, error) {
+func CreateStack(opts *CreateStackOptions) (*cloudformation.DescribeStacksOutput, error) {
 	_, err := opts.CloudFormationService.CreateStack(&cloudformation.CreateStackInput{
 		StackName:    aws.String(opts.StackName),
 		TemplateBody: aws.String(opts.TemplateBody),
@@ -154,7 +154,7 @@ type CreateLaunchTemplateOptions struct {
 	Config     *eksv1.EKSClusterConfig
 }
 
-func CreateLaunchTemplate(opts CreateLaunchTemplateOptions) error {
+func CreateLaunchTemplate(opts *CreateLaunchTemplateOptions) error {
 	_, err := opts.EC2Service.DescribeLaunchTemplates(&ec2.DescribeLaunchTemplatesInput{
 		LaunchTemplateIds: []*string{aws.String(opts.Config.Status.ManagedLaunchTemplateID)},
 	})
@@ -212,7 +212,7 @@ type CreateNodeGroupOptions struct {
 	NodeGroup eksv1.NodeGroup
 }
 
-func CreateNodeGroup(opts CreateNodeGroupOptions) (string, string, error) {
+func CreateNodeGroup(opts *CreateNodeGroupOptions) (string, string, error) {
 	var err error
 	capacityType := eks.CapacityTypesOnDemand
 	if aws.BoolValue(opts.NodeGroup.RequestSpotInstances) {
@@ -274,7 +274,7 @@ func CreateNodeGroup(opts CreateNodeGroupOptions) (string, string, error) {
 	if aws.StringValue(opts.NodeGroup.NodeRole) == "" {
 		if opts.Config.Status.GeneratedNodeRole == "" {
 			finalTemplate := fmt.Sprintf(templates.NodeInstanceRoleTemplate, getEC2ServiceEndpoint(opts.Config.Spec.Region))
-			output, err := CreateStack(CreateStackOptions{
+			output, err := CreateStack(&CreateStackOptions{
 				CloudFormationService: opts.CloudFormationService,
 				StackName:             fmt.Sprintf("%s-node-instance-role", opts.Config.Spec.DisplayName),
 				DisplayName:           opts.Config.Spec.DisplayName,

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -40,12 +40,12 @@ var _ = Describe("CreateCluster", func() {
 
 	It("should successfully create a cluster", func() {
 		eksServiceMock.EXPECT().CreateCluster(gomock.Any()).Return(nil, nil)
-		Expect(CreateCluster(*clustercCreateOptions)).To(Succeed())
+		Expect(CreateCluster(clustercCreateOptions)).To(Succeed())
 	})
 
 	It("should fail to create a cluster", func() {
 		eksServiceMock.EXPECT().CreateCluster(gomock.Any()).Return(nil, errors.New("error creating cluster"))
-		Expect(CreateCluster(*clustercCreateOptions)).ToNot(Succeed())
+		Expect(CreateCluster(clustercCreateOptions)).ToNot(Succeed())
 	})
 })
 
@@ -185,7 +185,7 @@ var _ = Describe("CreateStack", func() {
 				},
 			}, nil)
 
-		describeStacksOutput, err := CreateStack(*stackCreationOptions)
+		describeStacksOutput, err := CreateStack(stackCreationOptions)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(describeStacksOutput).ToNot(BeNil())
@@ -194,7 +194,7 @@ var _ = Describe("CreateStack", func() {
 	It("should fail to create a stack if CreateStack returns error", func() {
 		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, errors.New("error"))
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -207,7 +207,7 @@ var _ = Describe("CreateStack", func() {
 			},
 		).Return(&cloudformation.DescribeStacksOutput{}, nil)
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -222,7 +222,7 @@ var _ = Describe("CreateStack", func() {
 				},
 			}, nil)
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -230,7 +230,7 @@ var _ = Describe("CreateStack", func() {
 		cloudFormationsServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
 		cloudFormationsServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(nil, errors.New("error"))
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -259,7 +259,7 @@ var _ = Describe("CreateStack", func() {
 				},
 			}, nil)
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(createFailedStatus))
 	})
@@ -289,7 +289,7 @@ var _ = Describe("CreateStack", func() {
 				},
 			}, nil)
 
-		_, err := CreateStack(*stackCreationOptions)
+		_, err := CreateStack(stackCreationOptions)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring(rollbackInProgressStatus))
 	})
@@ -395,7 +395,7 @@ var _ = Describe("CreateLaunchTemplate", func() {
 			},
 		).Return(nil, nil)
 
-		Expect(CreateLaunchTemplate(*createLaunchTemplateOpts)).To(Succeed())
+		Expect(CreateLaunchTemplate(createLaunchTemplateOpts)).To(Succeed())
 		Expect(createLaunchTemplateOpts.Config.Status.ManagedLaunchTemplateID).To(Equal("testID"))
 	})
 
@@ -414,7 +414,7 @@ var _ = Describe("CreateLaunchTemplate", func() {
 			},
 		).Return(nil, errors.New("does not exist"))
 
-		Expect(CreateLaunchTemplate(*createLaunchTemplateOpts)).To(Succeed())
+		Expect(CreateLaunchTemplate(createLaunchTemplateOpts)).To(Succeed())
 		Expect(createLaunchTemplateOpts.Config.Status.ManagedLaunchTemplateID).To(Equal("testID"))
 	})
 
@@ -425,12 +425,12 @@ var _ = Describe("CreateLaunchTemplate", func() {
 			},
 		).Return(nil, nil)
 
-		Expect(CreateLaunchTemplate(*createLaunchTemplateOpts)).To(Succeed())
+		Expect(CreateLaunchTemplate(createLaunchTemplateOpts)).To(Succeed())
 	})
 
 	It("should fail to create a launch template if DescribeLaunchTemplates returns error", func() {
 		ec2ServiceMock.EXPECT().DescribeLaunchTemplates(gomock.Any()).Return(nil, errors.New("error"))
-		Expect(CreateLaunchTemplate(*createLaunchTemplateOpts)).ToNot(Succeed())
+		Expect(CreateLaunchTemplate(createLaunchTemplateOpts)).ToNot(Succeed())
 	})
 
 	It("should fail to create a launch template if CreateLaunchTemplate return error", func() {
@@ -439,7 +439,7 @@ var _ = Describe("CreateLaunchTemplate", func() {
 
 		ec2ServiceMock.EXPECT().CreateLaunchTemplate(gomock.Any()).Return(nil, errors.New("error"))
 
-		Expect(CreateLaunchTemplate(*createLaunchTemplateOpts)).ToNot(Succeed())
+		Expect(CreateLaunchTemplate(createLaunchTemplateOpts)).ToNot(Succeed())
 	})
 })
 
@@ -729,7 +729,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			NodeRole:      aws.String("test"),
 		}).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -762,7 +762,7 @@ var _ = Describe("CreateNodeGroup", func() {
 
 		eksServiceMock.EXPECT().CreateNodegroup(gomock.Any()).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -789,7 +789,7 @@ var _ = Describe("CreateNodeGroup", func() {
 
 		eksServiceMock.EXPECT().CreateNodegroup(gomock.Any()).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -829,7 +829,7 @@ var _ = Describe("CreateNodeGroup", func() {
 		eksServiceMock.EXPECT().CreateNodegroup(gomock.Any()).Return(nil, errors.New("error"))
 		ec2ServiceMock.EXPECT().DeleteLaunchTemplateVersions(gomock.Any()).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).To(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -847,7 +847,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			},
 		}, nil)
 
-		_, _, err := CreateNodeGroup(*createNodeGroupOpts)
+		_, _, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -906,7 +906,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			NodeRole:      aws.String("test"),
 		}).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -962,7 +962,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			AmiType:       aws.String(eks.AMITypesAl2X8664Gpu),
 		}).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))
@@ -1016,7 +1016,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			AmiType:       aws.String(eks.AMITypesAl2X8664),
 		}).Return(nil, nil)
 
-		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(*createNodeGroupOpts)
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(launchTemplateVersion).To(Equal("1"))

--- a/pkg/eks/get.go
+++ b/pkg/eks/get.go
@@ -15,7 +15,7 @@ type GetClusterStatusOpts struct {
 	Config     *eksv1.EKSClusterConfig
 }
 
-func GetClusterState(opts GetClusterStatusOpts) (*eks.DescribeClusterOutput, error) {
+func GetClusterState(opts *GetClusterStatusOpts) (*eks.DescribeClusterOutput, error) {
 	return opts.EKSService.DescribeCluster(
 		&eks.DescribeClusterInput{
 			Name: aws.String(opts.Config.Spec.DisplayName),
@@ -28,7 +28,7 @@ type GetLaunchTemplateVersionsOpts struct {
 	Versions         []*string
 }
 
-func GetLaunchTemplateVersions(opts GetLaunchTemplateVersionsOpts) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
+func GetLaunchTemplateVersions(opts *GetLaunchTemplateVersionsOpts) (*ec2.DescribeLaunchTemplateVersionsOutput, error) {
 	if opts.LaunchTemplateID == nil {
 		return nil, fmt.Errorf("launch template ID is nil")
 	}

--- a/pkg/eks/get_test.go
+++ b/pkg/eks/get_test.go
@@ -43,14 +43,14 @@ var _ = Describe("GetClusterState", func() {
 				Name: aws.String(getClusterStatusOptions.Config.Spec.DisplayName),
 			},
 		).Return(&eks.DescribeClusterOutput{}, nil)
-		clusterState, err := GetClusterState(*getClusterStatusOptions)
+		clusterState, err := GetClusterState(getClusterStatusOptions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(clusterState).ToNot(BeNil())
 	})
 
 	It("should fail to get cluster state", func() {
 		eksServiceMock.EXPECT().DescribeCluster(gomock.Any()).Return(nil, errors.New("error getting cluster state"))
-		_, err := GetClusterState(*getClusterStatusOptions)
+		_, err := GetClusterState(getClusterStatusOptions)
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -83,26 +83,26 @@ var _ = Describe("GetLaunchTemplateVersions", func() {
 				Versions:         getLaunchTemplateOptions.Versions,
 			},
 		).Return(&ec2.DescribeLaunchTemplateVersionsOutput{}, nil)
-		ltVersion, err := GetLaunchTemplateVersions(*getLaunchTemplateOptions)
+		ltVersion, err := GetLaunchTemplateVersions(getLaunchTemplateOptions)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(ltVersion).ToNot(BeNil())
 	})
 
 	It("should fail to get launch template versions", func() {
 		ec2ServiceMock.EXPECT().DescribeLaunchTemplateVersions(gomock.Any()).Return(nil, errors.New("error getting launch template versions"))
-		_, err := GetLaunchTemplateVersions(*getLaunchTemplateOptions)
+		_, err := GetLaunchTemplateVersions(getLaunchTemplateOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail to get launch template versions when template id is missing", func() {
 		getLaunchTemplateOptions.LaunchTemplateID = nil
-		_, err := GetLaunchTemplateVersions(*getLaunchTemplateOptions)
+		_, err := GetLaunchTemplateVersions(getLaunchTemplateOptions)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should fail to get launch template versions when versions are missing", func() {
 		getLaunchTemplateOptions.Versions = nil
-		_, err := GetLaunchTemplateVersions(*getLaunchTemplateOptions)
+		_, err := GetLaunchTemplateVersions(getLaunchTemplateOptions)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -21,7 +21,7 @@ type UpdateClusterVersionOpts struct {
 	UpstreamClusterSpec *eksv1.EKSClusterConfigSpec
 }
 
-func UpdateClusterVersion(opts UpdateClusterVersionOpts) (bool, error) {
+func UpdateClusterVersion(opts *UpdateClusterVersionOpts) (bool, error) {
 	updated := false
 	if aws.StringValue(opts.UpstreamClusterSpec.KubernetesVersion) != aws.StringValue(opts.Config.Spec.KubernetesVersion) {
 		logrus.Infof("updating kubernetes version for cluster [%s]", opts.Config.Name)
@@ -46,7 +46,7 @@ type UpdateResourceTagsOpts struct {
 	ResourceARN  string
 }
 
-func UpdateResourceTags(opts UpdateResourceTagsOpts) (bool, error) {
+func UpdateResourceTags(opts *UpdateResourceTagsOpts) (bool, error) {
 	updated := false
 	if updateTags := utils.GetKeyValuesToUpdate(opts.Tags, opts.UpstreamTags); updateTags != nil {
 		_, err := opts.EKSService.TagResource(
@@ -81,7 +81,7 @@ type UpdateLoggingTypesOpts struct {
 	UpstreamClusterSpec *eksv1.EKSClusterConfigSpec
 }
 
-func UpdateClusterLoggingTypes(opts UpdateLoggingTypesOpts) (bool, error) {
+func UpdateClusterLoggingTypes(opts *UpdateLoggingTypesOpts) (bool, error) {
 	updated := false
 	if loggingTypesUpdate := getLoggingTypesUpdate(opts.Config.Spec.LoggingTypes, opts.UpstreamClusterSpec.LoggingTypes); loggingTypesUpdate != nil {
 		_, err := opts.EKSService.UpdateClusterConfig(
@@ -105,7 +105,7 @@ type UpdateClusterAccessOpts struct {
 	UpstreamClusterSpec *eksv1.EKSClusterConfigSpec
 }
 
-func UpdateClusterAccess(opts UpdateClusterAccessOpts) (bool, error) {
+func UpdateClusterAccess(opts *UpdateClusterAccessOpts) (bool, error) {
 	updated := false
 
 	publicAccessUpdate := opts.Config.Spec.PublicAccess != nil && aws.BoolValue(opts.UpstreamClusterSpec.PublicAccess) != aws.BoolValue(opts.Config.Spec.PublicAccess)
@@ -137,7 +137,7 @@ type UpdateClusterPublicAccessSourcesOpts struct {
 	UpstreamClusterSpec *eksv1.EKSClusterConfigSpec
 }
 
-func UpdateClusterPublicAccessSources(opts UpdateClusterPublicAccessSourcesOpts) (bool, error) {
+func UpdateClusterPublicAccessSources(opts *UpdateClusterPublicAccessSourcesOpts) (bool, error) {
 	updated := false
 	// check public access CIDRs for update (public access sources)
 
@@ -171,7 +171,7 @@ type UpdateNodegroupVersionOpts struct {
 	LTVersions     map[string]string
 }
 
-func UpdateNodegroupVersion(opts UpdateNodegroupVersionOpts) error {
+func UpdateNodegroupVersion(opts *UpdateNodegroupVersionOpts) error {
 	if _, err := opts.EKSService.UpdateNodegroupVersion(opts.NGVersionInput); err != nil {
 		if version, ok := opts.LTVersions[aws.StringValue(opts.NodeGroup.NodegroupName)]; ok {
 			// If there was an error updating the node group and a Rancher-managed launch template version was created,

--- a/pkg/eks/update_test.go
+++ b/pkg/eks/update_test.go
@@ -51,21 +51,21 @@ var _ = Describe("UpdateClusterVersion", func() {
 				Version: updateClusterVersionOptions.Config.Spec.KubernetesVersion,
 			},
 		).Return(nil, nil)
-		updated, err := UpdateClusterVersion(*updateClusterVersionOptions)
+		updated, err := UpdateClusterVersion(updateClusterVersionOptions)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not update cluster version if version didn't change", func() {
 		updateClusterVersionOptions.UpstreamClusterSpec.KubernetesVersion = aws.String("test1")
-		updated, err := UpdateClusterVersion(*updateClusterVersionOptions)
+		updated, err := UpdateClusterVersion(updateClusterVersionOptions)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error if update cluster version failed", func() {
 		eksServiceMock.EXPECT().UpdateClusterVersion(gomock.Any()).Return(nil, errors.New("error updating cluster version"))
-		updated, err := UpdateClusterVersion(*updateClusterVersionOptions)
+		updated, err := UpdateClusterVersion(updateClusterVersionOptions)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -115,7 +115,7 @@ var _ = Describe("UpdateResourceTags", func() {
 				TagKeys:     []*string{aws.String("test3")},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -133,7 +133,7 @@ var _ = Describe("UpdateResourceTags", func() {
 				},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -149,7 +149,7 @@ var _ = Describe("UpdateResourceTags", func() {
 				TagKeys:     []*string{aws.String("test3")},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -163,14 +163,14 @@ var _ = Describe("UpdateResourceTags", func() {
 			"test1": "test1",
 			"test2": "test2",
 		}
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error if update cluster tags failed", func() {
 		eksServiceMock.EXPECT().TagResource(gomock.Any()).Return(nil, errors.New("error tagging resource"))
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -178,7 +178,7 @@ var _ = Describe("UpdateResourceTags", func() {
 	It("should return error if untag cluster tags failed", func() {
 		eksServiceMock.EXPECT().TagResource(gomock.Any()).Return(nil, nil)
 		eksServiceMock.EXPECT().UntagResource(gomock.Any()).Return(nil, errors.New("error untagging resource"))
-		updated, err := UpdateResourceTags(*updateResourceTagsOpts)
+		updated, err := UpdateResourceTags(updateResourceTagsOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -229,21 +229,21 @@ var _ = Describe("UpdateLoggingTypes", func() {
 				},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateClusterLoggingTypes(*updateLoggingTypesOpts)
+		updated, err := UpdateClusterLoggingTypes(updateLoggingTypesOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not update cluster logging types if logging types didn't change", func() {
 		updateLoggingTypesOpts.UpstreamClusterSpec.LoggingTypes = []string{"test1", "test2", "test3-enabled"}
-		updated, err := UpdateClusterLoggingTypes(*updateLoggingTypesOpts)
+		updated, err := UpdateClusterLoggingTypes(updateLoggingTypesOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error if update cluster logging types failed", func() {
 		eksServiceMock.EXPECT().UpdateClusterConfig(gomock.Any()).Return(nil, errors.New("error updating cluster config"))
-		updated, err := UpdateClusterLoggingTypes(*updateLoggingTypesOpts)
+		updated, err := UpdateClusterLoggingTypes(updateLoggingTypesOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -288,7 +288,7 @@ var _ = Describe("UpdateClusterAccess", func() {
 				},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateClusterAccess(*updateClusterAccessOpts)
+		updated, err := UpdateClusterAccess(updateClusterAccessOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -296,14 +296,14 @@ var _ = Describe("UpdateClusterAccess", func() {
 	It("should not update cluster access if access didn't change", func() {
 		updateClusterAccessOpts.UpstreamClusterSpec.PrivateAccess = aws.Bool(true)
 		updateClusterAccessOpts.UpstreamClusterSpec.PublicAccess = aws.Bool(true)
-		updated, err := UpdateClusterAccess(*updateClusterAccessOpts)
+		updated, err := UpdateClusterAccess(updateClusterAccessOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error if update cluster access failed", func() {
 		eksServiceMock.EXPECT().UpdateClusterConfig(gomock.Any()).Return(nil, errors.New("error updating cluster config"))
-		updated, err := UpdateClusterAccess(*updateClusterAccessOpts)
+		updated, err := UpdateClusterAccess(updateClusterAccessOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -345,21 +345,21 @@ var _ = Describe("UpdateClusterPublicAccessSources", func() {
 				},
 			},
 		).Return(nil, nil)
-		updated, err := UpdateClusterPublicAccessSources(*updateClusterPublicAccessSourcesOpts)
+		updated, err := UpdateClusterPublicAccessSources(updateClusterPublicAccessSourcesOpts)
 		Expect(updated).To(BeTrue())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not update cluster public access sources if public access sources didn't change", func() {
 		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.PublicAccessSources = []string{"test1", "test2"}
-		updated, err := UpdateClusterPublicAccessSources(*updateClusterPublicAccessSourcesOpts)
+		updated, err := UpdateClusterPublicAccessSources(updateClusterPublicAccessSourcesOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should return error if update cluster public access sources failed", func() {
 		eksServiceMock.EXPECT().UpdateClusterConfig(gomock.Any()).Return(nil, errors.New("error updating cluster config"))
-		updated, err := UpdateClusterPublicAccessSources(*updateClusterPublicAccessSourcesOpts)
+		updated, err := UpdateClusterPublicAccessSources(updateClusterPublicAccessSourcesOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).To(HaveOccurred())
 	})
@@ -398,12 +398,12 @@ var _ = Describe("UpdateNodegroupVersion", func() {
 
 	It("should update node group version", func() {
 		eksServiceMock.EXPECT().UpdateNodegroupVersion(updateNodegroupVersionOpts.NGVersionInput).Return(nil, nil)
-		Expect(UpdateNodegroupVersion(*updateNodegroupVersionOpts)).To(Succeed())
+		Expect(UpdateNodegroupVersion(updateNodegroupVersionOpts)).To(Succeed())
 	})
 
 	It("should delete launch template version if update fails", func() {
 		eksServiceMock.EXPECT().UpdateNodegroupVersion(updateNodegroupVersionOpts.NGVersionInput).Return(nil, errors.New("error"))
 		ec2ServiceMock.EXPECT().DeleteLaunchTemplateVersions(gomock.Any()).Return(nil, nil)
-		Expect(UpdateNodegroupVersion(*updateNodegroupVersionOpts)).To(HaveOccurred())
+		Expect(UpdateNodegroupVersion(updateNodegroupVersionOpts)).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This PR fixes couple of issues:
- Remove AWS clients from the handler structure, currently, we reassign clients on each reconciliation. It hasn't been an issue but is not an ideal solution.
- Initialize AWS clients also in `OnEksConfigRemoved`
- Make arguments for AWS service calls pointers because they sometimes have to modify input objects. 
