### PR TITLE
Fix chart update workflow

### DIFF
--- a/.github/scripts/update-rancher-charts.sh
+++ b/.github/scripts/update-rancher-charts.sh
@@ -33,8 +33,9 @@ find ./packages/rancher-eks-operator/ -type f -exec sed -i -e "s/version: ${PREV
 if [ "${REPLACE}" == "true" ]; then
     sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}/${NEW_CHART_VERSION}+up${NEW_EKS_OPERATOR_VERSION}/g" release.yaml
 else
-    sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}/${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}\n${NEW_CHART_VERSION}+up${NEW_EKS_OPERATOR_VERSION}/g" release.yaml
-    if grep -qv "rancher-eks-operator:" release.yaml; then
+    sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}/${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}\n  - ${NEW_CHART_VERSION}+up${NEW_EKS_OPERATOR_VERSION}/g" release.yaml
+    isChartPresent=$(cat release.yaml | grep -c "rancher-eks-operator:")
+    if [ $isChartPresent -eq 0 ]; then
 
         cat <<< "rancher-eks-operator:
 - ${PREV_CHART_VERSION}+up${PREV_EKS_OPERATOR_VERSION}


### PR DESCRIPTION
If we're adding a new version to [release.yaml](https://github.com/rancher/charts/blob/dev-v2.7/release.yaml) there 2 things the script can do:
- If eks-operator record is present in the list, it should add new version to the list, currently `sed` instruction for it is broken because it doesn't add proper indentation.
- If eks-operator record is not present, the script creates it. In the current implementation, `if grep -qv "rancher-eks-operator:" release.yaml; then` doesn't work as expected so I replaced it with a new command.

Result of the test run: https://github.com/rancher/charts/pull/2706