### PR TITLE
Fix error when creating node group from launch template with custom AMI

### DIFF
--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -256,7 +256,9 @@ func CreateNodeGroup(opts *CreateNodeGroupOptions) (string, string, error) {
 	}
 
 	if aws.StringValue(opts.NodeGroup.ImageID) == "" {
-		if gpu := opts.NodeGroup.Gpu; aws.BoolValue(gpu) {
+		if opts.NodeGroup.LaunchTemplate != nil {
+			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesCustom)
+		} else if gpu := opts.NodeGroup.Gpu; aws.BoolValue(gpu) {
 			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2X8664Gpu)
 		} else {
 			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2X8664)


### PR DESCRIPTION
### Issue #90 

## Problem

If a user creates a node group from a launch template that uses a custom AMI, the creation fails with the following error:
```
You cannot specify an AMI Type other than CUSTOM, when specifying an image id in your launch template.
```
When using a custom AMI, the call to the AWS SDK `CreateNodeGroup` must specify `amiType: CUSTOM`. Any other value triggers this error.

The function `CreateNodeGroup` in [create.go](https://github.com/salasberryfin/eks-operator/blob/ff63cc244ade590af9f283f7c1e1655e3ce4124e/pkg/eks/create.go#L258) sets the value of `AmiType` which cannot be overriden by user configuration.

## Solution

To allow using launch templates with custom AMIs, a new condition is added to the logic that sets `AmiType`, setting `eks.AMITypeCustom` if user has provided a launch template.