### PR TITLE
chore: added nightly build & publish

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -1,0 +1,34 @@
+name: Nightly
+on:
+  schedule:
+    - cron: '0 1 * * *'
+jobs:
+  nightly:
+    env:
+        REPO: ttl.sh/eks-operator-nightly
+        TAG: 1d
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Set current date as env variable
+        run: echo "NOW=$(date +'%Y%m%d')" >> $GITHUB_ENV
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2.5.0
+      - name: Build and push image
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          tags: ${{ env.REPO}}-${{ env.NOW }}:${{ env.TAG }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          target: eks-operator
+          file: test/e2e/Dockerfile.e2e
+          build-args: |
+            TAG=${{ env.TAG }}
+            REPO=${{ env.REPO }}-${{ env.NOW }}
+            COMMIT=${{ github.sha }}


### PR DESCRIPTION
Added a GHA workflow that will build and publish the operator every night to ttl.sh. This is to aid testing the HEAD.

Relates: #192 