### PR TITLE
Fix CVE vulnerabilities

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 RUN zypper -n update && \
     zypper -n clean -a && \
     rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*


### PR DESCRIPTION
#### Issue rancher/highlander#13

### Description

The base image `bci-base` is updated from `15.4` to `15.5` to fix the vulnerabilities reported by rancherlabs/image-scanning#2285 on the latest release of the operator. Since v1.2.0 was released, dependabot has also updated the reported Go modules.
 
After bumping the base image version and dependencies, we'll ask QA to run regression tests to confirm we're good with the updates.