### PR TITLE
fix: tag instances resources

### DIFF
--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -243,6 +243,10 @@ func CreateNodeGroup(opts *CreateNodeGroupOptions) (string, string, error) {
 
 	lt := opts.NodeGroup.LaunchTemplate
 
+	if len(opts.NodeGroup.ResourceTags) > 0 {
+		nodeGroupCreateInput.Tags = opts.NodeGroup.ResourceTags
+	}
+
 	if lt == nil {
 		// In this case, the user has not specified their own launch template.
 		// If the cluster doesn't have a launch template associated with it, then we create one.

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -1023,6 +1023,72 @@ var _ = Describe("CreateNodeGroup", func() {
 		Expect(launchTemplateVersion).To(Equal("1"))
 		Expect(generatedNodeRole).To(Equal("test"))
 	})
+	It("set resource tags", func() {
+		createNodeGroupOpts.NodeGroup.ResourceTags = map[string]*string{
+			"tag1": aws.String("val1"),
+		}
+
+		ec2ServiceMock.EXPECT().CreateLaunchTemplateVersion(gomock.Any()).Return(&ec2.CreateLaunchTemplateVersionOutput{
+			LaunchTemplateVersion: &ec2.LaunchTemplateVersion{
+				LaunchTemplateName: aws.String("test"),
+				LaunchTemplateId:   aws.String("test"),
+				VersionNumber:      aws.Int64(1),
+			},
+		}, nil)
+
+		ec2ServiceMock.EXPECT().DescribeImages(gomock.Any()).Return(&ec2.DescribeImagesOutput{
+			Images: []*ec2.Image{
+				{
+					RootDeviceName: aws.String("test"),
+				},
+			},
+		}, nil)
+
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+			&cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					{
+						StackStatus: aws.String(createCompleteStatus),
+						Outputs: []*cloudformation.Output{
+							{
+								OutputKey:   aws.String("NodeInstanceRole"),
+								OutputValue: aws.String("test"),
+							},
+						},
+					},
+				},
+			}, nil)
+
+		eksServiceMock.EXPECT().CreateNodegroup(&eks.CreateNodegroupInput{
+			ClusterName:   aws.String(createNodeGroupOpts.Config.Spec.DisplayName),
+			NodegroupName: createNodeGroupOpts.NodeGroup.NodegroupName,
+			Labels:        createNodeGroupOpts.NodeGroup.Labels,
+			ScalingConfig: &eks.NodegroupScalingConfig{
+				DesiredSize: createNodeGroupOpts.NodeGroup.DesiredSize,
+				MaxSize:     createNodeGroupOpts.NodeGroup.MaxSize,
+				MinSize:     createNodeGroupOpts.NodeGroup.MinSize,
+			},
+			CapacityType: aws.String(eks.CapacityTypesSpot),
+			LaunchTemplate: &eks.LaunchTemplateSpecification{
+				Id:      aws.String("test"),
+				Version: aws.String("1"),
+			},
+			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
+			Subnets:       aws.StringSlice(createNodeGroupOpts.NodeGroup.Subnets),
+			NodeRole:      aws.String("test"),
+			Tags: map[string]*string{
+				"tag1": aws.String("val1"),
+			},
+		}).Return(nil, nil)
+
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(launchTemplateVersion).To(Equal("1"))
+		Expect(generatedNodeRole).To(Equal("test"))
+	})
 })
 
 var _ = Describe("installEBSCSIDriver", func() {

--- a/utils/map.go
+++ b/utils/map.go
@@ -108,6 +108,14 @@ func CreateTagSpecs(instanceTags map[string]*string) []*ec2.LaunchTemplateTagSpe
 			ResourceType: aws.String(ec2.ResourceTypeInstance),
 			Tags:         tags,
 		},
+		{
+			ResourceType: aws.String(ec2.ResourceTypeVolume),
+			Tags:         tags,
+		},
+		{
+			ResourceType: aws.String(ec2.ResourceTypeSpotInstancesRequest),
+			Tags:         tags,
+		},
 	}
 }
 


### PR DESCRIPTION
This change includes a fix to ensure that the instance resource tags are properly propogated to resources via the launch template.

Issue: #205 