### PR TITLE
fix: rancher panics when node group fails

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -885,6 +885,9 @@ func BuildUpstreamClusterState(name, managedTemplateID string, clusterState *eks
 				}
 				launchTemplateData := launchTemplateRequestOutput.LaunchTemplateVersions[0].LaunchTemplateData
 
+				if len(launchTemplateData.BlockDeviceMappings) == 0 {
+					return nil, "", fmt.Errorf("launch template for node group [%s] in cluster [%s] is malformed", aws.StringValue(ngToAdd.NodegroupName), upstreamSpec.DisplayName)
+				}
 				ngToAdd.DiskSize = launchTemplateData.BlockDeviceMappings[0].Ebs.VolumeSize
 				ngToAdd.Ec2SshKey = launchTemplateData.KeyName
 				ngToAdd.ImageID = launchTemplateData.ImageId


### PR DESCRIPTION
### Issue #169 

## Description

This panic is caused by a node group created from the AWS Console using a malformed launch template. This was specifically detected while trying to use the default version of the Rancher-managed launch template, which only contains a placeholder string in the user data.