### PR TITLE
[v2.8] fix: cluster config not showing launch template versions 

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -1061,7 +1061,8 @@ func (h *Handler) updateUpstreamClusterState(upstreamSpec *eksv1.EKSClusterConfi
 		// nodegroup may not be immediate
 		if config.Status.Phase != eksConfigUpdatingPhase {
 			config.Status.Phase = eksConfigUpdatingPhase
-			config, err := h.eksCC.UpdateStatus(config)
+			var err error
+			config, err = h.eksCC.UpdateStatus(config)
 			if err != nil {
 				return config, err
 			}


### PR DESCRIPTION
This bug was initially reported by @cpinjani while validating launch template behavior in the Rancher Dashboard https://github.com/rancher/dashboard/issues/9606

## Description

With `eks-operator:v1.2.1` the list of versions of Rancher-managed launch templates was not properly populated in the cluster's yaml `eksStatus`, which made the launch template information unavailable in the UI.