### PR TITLE
🌱 Group k8s.io dependency updates and add aws-sdk-go to ignore list

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,11 +12,23 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
   ignore:
+  # Ignore controller-runtime as its upgraded manually.
   - dependency-name: "sigs.k8s.io/controller-runtime"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - dependency-name: "go.etcd.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
   - dependency-name: "github.com/rancher/wrangler"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore aws-sdk-go
+  - dependency-name: "github.com/aws/aws-sdk-go"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
This PR:

* Allows patch updates on dependabot ignore list
* Add dependencys group for dependabot
