### PR TITLE
Improve dependabot to track other branches

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
-# Go
+# Go modules in main branch
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -32,3 +32,56 @@ updates:
   # Ignore aws-sdk-go
   - dependency-name: "github.com/aws/aws-sdk-go"
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  target-branch: "main"
+# Go modules in release-v2.8 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  - dependency-name: "go.etcd.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore wrangler
+  - dependency-name: "github.com/rancher/wrangler"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore aws-sdk-go
+  - dependency-name: "github.com/aws/aws-sdk-go"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  target-branch: "release-v2.8"
+# Go modules in release-v2.8 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ## group all dependencies with a k8s.io prefix into a single PR.
+  groups:
+    kubernetes:
+      patterns: [ "k8s.io/*" ]
+  ignore:
+  # Ignore controller-runtime as its upgraded manually.
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  - dependency-name: "go.etcd.io/*"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore wrangler
+  - dependency-name: "github.com/rancher/wrangler"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  # Ignore aws-sdk-go
+  - dependency-name: "github.com/aws/aws-sdk-go"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it:**

We have to check outdated dependency also for `release-v2.8` and `release-v2.7` branches