### PR TITLE
chore: use reusable workflow for nightly publish

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -2,67 +2,11 @@ name: Nightly
 on:
   schedule:
     - cron: '0 1 * * *'
+  workflow_dispatch:
 jobs:
-  nightly_image:
-    env:
-        REPO_BASE: ttl.sh/eks-operator-nightly
-        TAG: 1d
-    runs-on: ubuntu-latest
-    outputs:
-      REPO: ${{ steps.setoutputs.outputs.repo}}
-      BUILD_DATE: ${{ steps.setoutputs.outputs.builddate}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-      - name: Set current date as env variable
-        run: echo "NOW=$(date +'%Y%m%d')" >> $GITHUB_ENV
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3.0.0
-      - name: Build and push image
-        uses: docker/build-push-action@v5.1.0
-        with:
-          context: .
-          tags: ${{ env.REPO_BASE}}-${{ env.NOW }}:${{ env.TAG }}
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          target: eks-operator
-          file: test/e2e/Dockerfile.e2e
-          build-args: |
-            TAG=${{ env.TAG }}
-            REPO=${{ env.REPO_BASE }}-${{ env.NOW }}
-            COMMIT=${{ github.sha }}
-      - name: Set outputs
-        id: setoutputs
-        run: |
-          echo "repo=${{ env.REPO_BASE }}-${{ env.NOW }}" >> "$GITHUB_OUTPUT"
-          echo "builddate=${{ env.NOW }}" >> "$GITHUB_OUTPUT"
-  nightly_charts:
-    env:
-        REPO: ${{ needs.nightly_image.outputs.REPO }}
-        TAG: 1d
-        BUILD_DATE: ${{ needs.nightly_image.outputs.BUILD_DATE }}
-    runs-on: ubuntu-latest
-    needs: nightly_image
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-            version: 'v3.12.1'
-      - name: Build charts
-        run: |
-          make charts
-        env:
-            CHART_VERSION: ${{ env.BUILD_DATE }}
-            GIT_TAG: ${{ env.BUILD_DATE }}
-      - name: Push charts
-        run: |
-          helm push bin/rancher-eks-operator-crd-${{ env.BUILD_DATE }}.tgz oci://ttl.sh/eks-operator
-          helm push bin/rancher-eks-operator-${{ env.BUILD_DATE }}.tgz oci://ttl.sh/eks-operator
+  publish_nightly:
+    uses: rancher-sandbox/highlander-reusable-workflows/.github/workflows/operator-with-latest-rancher-build.yaml@main
+    with:
+      operator_name: eks-operator
+      rancher_ref: release/v2.8
+      operator_commit: ${{ github.sha }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the reusable workflow for the nightly publish as we're already doing in other hosted providers. 

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
