### PR TITLE
test: add node group test to e2e

### DIFF
--- a/test/e2e/basic_cluster_test.go
+++ b/test/e2e/basic_cluster_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
@@ -55,5 +56,109 @@ var _ = Describe("BasicCluster", func() {
 
 			return fmt.Errorf("cluster is not ready yet. Current phase: %s", currentCluster.Status.Phase)
 		}, waitLong, pollInterval).ShouldNot(HaveOccurred())
+	})
+
+	It("Successfully adds and removes a node group", func() {
+		initialNodeGroups := eksConfig.DeepCopy().Spec.NodeGroups
+
+		Expect(cl.Get(ctx, runtimeclient.ObjectKey{Name: cluster.Name}, cluster)).Should(Succeed())
+		patch := runtimeclient.MergeFrom(cluster.DeepCopy())
+
+		nodeGroup := eksv1.NodeGroup{
+			NodegroupName:        aws.String("ng1"),
+			DiskSize:             aws.Int64(20),
+			InstanceType:         aws.String("t3.medium"),
+			DesiredSize:          aws.Int64(1),
+			MaxSize:              aws.Int64(10),
+			MinSize:              aws.Int64(1),
+			RequestSpotInstances: aws.Bool(false),
+		}
+
+		cluster.Spec.EKSConfig.NodeGroups = append(cluster.Spec.EKSConfig.NodeGroups, nodeGroup)
+
+		Expect(cl.Patch(ctx, cluster, patch)).Should(Succeed())
+
+		By("Waiting for cluster to start adding node group")
+		Eventually(func() error {
+			currentCluster := &eksv1.EKSClusterConfig{}
+
+			if err := cl.Get(ctx, runtimeclient.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: eksClusterConfigNamespace,
+			}, currentCluster); err != nil {
+				return err
+			}
+
+			if currentCluster.Status.Phase == "updating" && len(currentCluster.Spec.NodeGroups) == 2 {
+				return nil
+			}
+
+			return fmt.Errorf("cluster didn't create new new node group. Current phase: %s", currentCluster.Status.Phase)
+		}, waitLong, pollInterval).ShouldNot(HaveOccurred())
+
+		By("Waiting for cluster to finish adding node group")
+		Eventually(func() error {
+			currentCluster := &eksv1.EKSClusterConfig{}
+
+			if err := cl.Get(ctx, runtimeclient.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: eksClusterConfigNamespace,
+			}, currentCluster); err != nil {
+				return err
+			}
+
+			if currentCluster.Status.Phase == "active" && len(currentCluster.Spec.NodeGroups) == 2 {
+				return nil
+			}
+
+			return fmt.Errorf("cluster didn't finish adding node group. Current phase: %s, node group count %d", currentCluster.Status.Phase, len(currentCluster.Spec.NodeGroups))
+		}, waitLong, pollInterval).ShouldNot(HaveOccurred())
+
+		By("Restoring initial node groups")
+
+		Expect(cl.Get(ctx, runtimeclient.ObjectKey{Name: cluster.Name}, cluster)).Should(Succeed())
+		patch = runtimeclient.MergeFrom(cluster.DeepCopy())
+
+		cluster.Spec.EKSConfig.NodeGroups = initialNodeGroups
+
+		Expect(cl.Patch(ctx, cluster, patch)).Should(Succeed())
+
+		By("Waiting for cluster to start removing node group")
+		Eventually(func() error {
+			currentCluster := &eksv1.EKSClusterConfig{}
+
+			if err := cl.Get(ctx, runtimeclient.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: eksClusterConfigNamespace,
+			}, currentCluster); err != nil {
+				return err
+			}
+
+			if currentCluster.Status.Phase == "updating" && len(currentCluster.Spec.NodeGroups) == 1 {
+				return nil
+			}
+
+			return fmt.Errorf("cluster didn't start removing node group. Current phase: %s, node group count %d", currentCluster.Status.Phase, len(currentCluster.Spec.NodeGroups))
+		}, waitLong, pollInterval).ShouldNot(HaveOccurred())
+
+		By("Waiting for cluster to finish removing node group")
+		Eventually(func() error {
+			currentCluster := &eksv1.EKSClusterConfig{}
+
+			if err := cl.Get(ctx, runtimeclient.ObjectKey{
+				Name:      cluster.Name,
+				Namespace: eksClusterConfigNamespace,
+			}, currentCluster); err != nil {
+				return err
+			}
+
+			if currentCluster.Status.Phase == "active" && len(currentCluster.Spec.NodeGroups) == 1 {
+				return nil
+			}
+
+			return fmt.Errorf("cluster didn't finish removing node group. Current phase: %s, node group count %d", currentCluster.Status.Phase, len(currentCluster.Spec.NodeGroups))
+		}, waitLong, pollInterval).ShouldNot(HaveOccurred())
+
+		By("Done waiting for cluster to finish removing node group")
 	})
 })

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   amazonCredentialSecret: default:aws-credentials
   imported: false
   kmsKey: ""
-  kubernetesVersion: "1.25"
+  kubernetesVersion: "1.26"
   loggingTypes: []
   nodeGroups:
   - desiredSize: 2
@@ -26,7 +26,7 @@ spec:
     subnets: []
     tags: {}
     userData: ""
-    version: "1.25"
+    version: "1.26"
   privateAccess: false
   publicAccess: true
   publicAccessSources: []


### PR DESCRIPTION
**What this PR does / why we need it**:

Update E2E tests following existing test cases in other hosted providers.

This PR also updates Kubernetes version to v1.26 as end of standard support for v1.25 in EKS is approaching.

**Which issue(s) this PR fixes**
Issue #97 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
- [ ] backport needed 
