### PR TITLE
chore: add ignore rule for dependabot updates on wrangler v2

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,7 +28,9 @@ updates:
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
   - dependency-name: "github.com/rancher/wrangler"
-  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
+  - dependency-name: "github.com/rancher/wrangler/v2"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   # Ignore aws-sdk-go
   - dependency-name: "github.com/aws/aws-sdk-go"
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
@@ -54,7 +56,9 @@ updates:
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
   - dependency-name: "github.com/rancher/wrangler"
-  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
+  - dependency-name: "github.com/rancher/wrangler/v2"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   # Ignore aws-sdk-go
   - dependency-name: "github.com/aws/aws-sdk-go"
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
@@ -80,7 +84,9 @@ updates:
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
   - dependency-name: "github.com/rancher/wrangler"
-  update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
+  - dependency-name: "github.com/rancher/wrangler/v2"
+  update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   # Ignore aws-sdk-go
   - dependency-name: "github.com/aws/aws-sdk-go"
   update-types: [ "version-update:semver-major", "version-update:semver-minor" ]


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot is creating PRs for `wrangler` updates after the move to `github.com/rancher/wrangler/v2`, which is not covered in the existing ignore rule. This change also removes patch updates from being tracked.

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
