### PR TITLE
🌱 Add Arm support for EKS NodeGroup

### DIFF
--- a/charts/eks-operator-crd/templates/crds.yaml
+++ b/charts/eks-operator-crd/templates/crds.yaml
@@ -47,6 +47,9 @@ spec:
               nodeGroups:
                 items:
                   properties:
+                    arm:
+                      nullable: true
+                      type: boolean
                     desiredSize:
                       nullable: true
                       type: integer

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -547,6 +547,9 @@ func (h *Handler) validateCreate(config *eksv1.EKSClusterConfig, awsSVCs *awsSer
 				if !aws.BoolValue(ng.RequestSpotInstances) && ng.InstanceType == nil {
 					return fmt.Errorf(cannotBeNilError, "instanceType", *ng.NodegroupName, config.Name)
 				}
+				if aws.BoolValue(ng.Arm) && ng.InstanceType == nil {
+					return fmt.Errorf(cannotBeNilError, "instanceType", *ng.NodegroupName, config.Name)
+				}
 			}
 			if ng.NodegroupName == nil {
 				return fmt.Errorf(cannotBeNilError, "name", *ng.NodegroupName, config.Name)
@@ -933,6 +936,8 @@ func BuildUpstreamClusterState(name, managedTemplateID string, clusterState *eks
 			ngToAdd.Gpu = aws.Bool(true)
 		} else if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2X8664 {
 			ngToAdd.Gpu = aws.Bool(false)
+		} else if aws.StringValue(ng.Nodegroup.AmiType) == eks.AMITypesAl2Arm64 {
+			ngToAdd.Arm = aws.Bool(true)
 		}
 		upstreamSpec.NodeGroups = append(upstreamSpec.NodeGroups, ngToAdd)
 	}

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -68,6 +68,7 @@ type EKSClusterConfigStatus struct {
 
 type NodeGroup struct {
 	Gpu                  *bool              `json:"gpu"`
+	Arm                  *bool              `json:"arm"`
 	ImageID              *string            `json:"imageId" norman:"pointer"`
 	NodegroupName        *string            `json:"nodegroupName" norman:"required,pointer" wrangler:"required"`
 	DiskSize             *int64             `json:"diskSize"`

--- a/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
@@ -248,6 +248,11 @@ func (in *NodeGroup) DeepCopyInto(out *NodeGroup) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Arm != nil {
+		in, out := &in.Arm, &out.Arm
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ImageID != nil {
 		in, out := &in.ImageID, &out.ImageID
 		*out = new(string)

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -273,6 +273,8 @@ func CreateNodeGroup(opts *CreateNodeGroupOptions) (string, string, error) {
 	if aws.StringValue(opts.NodeGroup.ImageID) == "" {
 		if opts.NodeGroup.LaunchTemplate != nil {
 			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesCustom)
+		} else if arm := opts.NodeGroup.Arm; aws.BoolValue(arm) {
+			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2Arm64)
 		} else if gpu := opts.NodeGroup.Gpu; aws.BoolValue(gpu) {
 			nodeGroupCreateInput.AmiType = aws.String(eks.AMITypesAl2X8664Gpu)
 		} else {

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -970,6 +970,62 @@ var _ = Describe("CreateNodeGroup", func() {
 		Expect(generatedNodeRole).To(Equal("test"))
 	})
 
+	It("set Arm ami type", func() {
+		createNodeGroupOpts.NodeGroup.Arm = aws.Bool(true)
+		createNodeGroupOpts.NodeGroup.ImageID = nil
+
+		ec2ServiceMock.EXPECT().CreateLaunchTemplateVersion(gomock.Any()).Return(&ec2.CreateLaunchTemplateVersionOutput{
+			LaunchTemplateVersion: &ec2.LaunchTemplateVersion{
+				LaunchTemplateName: aws.String("test"),
+				LaunchTemplateId:   aws.String("test"),
+				VersionNumber:      aws.Int64(1),
+			},
+		}, nil)
+
+		cloudFormationServiceMock.EXPECT().CreateStack(gomock.Any()).Return(nil, nil)
+
+		cloudFormationServiceMock.EXPECT().DescribeStacks(gomock.Any()).Return(
+			&cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					{
+						StackStatus: aws.String(createCompleteStatus),
+						Outputs: []*cloudformation.Output{
+							{
+								OutputKey:   aws.String("NodeInstanceRole"),
+								OutputValue: aws.String("test"),
+							},
+						},
+					},
+				},
+			}, nil)
+
+		eksServiceMock.EXPECT().CreateNodegroup(&eks.CreateNodegroupInput{
+			ClusterName:   aws.String(createNodeGroupOpts.Config.Spec.DisplayName),
+			NodegroupName: createNodeGroupOpts.NodeGroup.NodegroupName,
+			Labels:        createNodeGroupOpts.NodeGroup.Labels,
+			ScalingConfig: &eks.NodegroupScalingConfig{
+				DesiredSize: createNodeGroupOpts.NodeGroup.DesiredSize,
+				MaxSize:     createNodeGroupOpts.NodeGroup.MaxSize,
+				MinSize:     createNodeGroupOpts.NodeGroup.MinSize,
+			},
+			CapacityType: aws.String(eks.CapacityTypesSpot),
+			LaunchTemplate: &eks.LaunchTemplateSpecification{
+				Id:      aws.String("test"),
+				Version: aws.String("1"),
+			},
+			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
+			Subnets:       aws.StringSlice(createNodeGroupOpts.NodeGroup.Subnets),
+			NodeRole:      aws.String("test"),
+			AmiType:       aws.String(eks.AMITypesAl2Arm64),
+		}).Return(nil, nil)
+
+		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(createNodeGroupOpts)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(launchTemplateVersion).To(Equal("1"))
+		Expect(generatedNodeRole).To(Equal("test"))
+	})
+
 	It("set ami type if image id not set", func() {
 		createNodeGroupOpts.NodeGroup.ImageID = nil
 		ec2ServiceMock.EXPECT().CreateLaunchTemplateVersion(gomock.Any()).Return(&ec2.CreateLaunchTemplateVersionOutput{

--- a/test/e2e/basic_cluster_test.go
+++ b/test/e2e/basic_cluster_test.go
@@ -66,8 +66,9 @@ var _ = Describe("BasicCluster", func() {
 
 		nodeGroup := eksv1.NodeGroup{
 			NodegroupName:        aws.String("ng1"),
+			Arm:                  aws.Bool(true),
 			DiskSize:             aws.Int64(20),
-			InstanceType:         aws.String("t3.medium"),
+			InstanceType:         aws.String("a1.large"),
 			DesiredSize:          aws.Int64(1),
 			MaxSize:              aws.Int64(10),
 			MinSize:              aws.Int64(1),

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,6 +8,6 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.11.1
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.9
+rancherVersion: 2.8.0
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
 

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -13,6 +13,7 @@ spec:
     diskSize: 20
     ec2SshKey: ""
     gpu: false
+    arm: false
     imageId: ""
     instanceType: t3.medium
     labels: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds support for ARM node groups. The new API field `Arm` was introduced in the NG properties and disabled by default,  and when it is set to `true` with the appropriate **instanceType** (i.e a1.large instead of t3.medium) for ARM, a node group will be created based off of the ARM AMI types. 

**Which issue(s) this PR fixes**
Issue #292 

**Special notes for your reviewer**:

To be able to use this feature:
1. A new operator release needs to be cut
2. A new release of the operator bumped in Rancher with a new field added in https://github.com/rancher/rancher/tree/release/v2.9/pkg/controllers/management/eks/test files
3. daily e2e tests might fail until then both of the above are completed

I have tested it by:
1. Releasing a new operator version from my [fork](https://github.com/furkatgofurov7/eks-operator/releases/tag/v1.4.0-rc1)
2. Bumping Rancher to the above version and [building a local container image](https://github.com/rancher/rancher/blob/release/v2.9/docs/development.md) pushed to the registry (DockerHub in this specific case)
4. Upgrading the rancher to use the locally built rancher image right after it is [installed](https://github.com/rancher/eks-operator/blob/d2754f9bbb793c6a5a90acaca562dc165564f575/test/e2e/suite_test.go#L121-L148) in e2e tests

```
helm upgrade rancher rancher-stable/rancher --namespace cattle-system --set bootstrapPassword=admin --set replicas=1 --set hostname=rancher.my.org --set rancherImage="registry/target-repo" --set rancherImageTag="imageTag"
```
4. Check one of the nodegroups (`ng1`) created using the `AL2_ARM_64` AMIType and `a1.large` instanceType while the other nodegroup (`nodenametest`) with `AL2_x86_64` AMIType and `t3.medium` instanceType.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [x] adds or updates e2e tests
- [x] backport needed 
