### PR TITLE
Add StartEC2Service and StartEKSService to external functions

### DIFF
--- a/controller/external.go
+++ b/controller/external.go
@@ -13,8 +13,31 @@ import (
 	awsservices "github.com/rancher/eks-operator/pkg/eks"
 	"github.com/rancher/eks-operator/pkg/eks/services"
 	"github.com/rancher/eks-operator/utils"
+	wranglerv1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
 )
+
+// StartEC2Service initializes and returns an instance of the EC2ServiceInterface
+// interface, which provides methods for interacting with the EC2 service in AWS.
+func StartEC2Service(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (services.EC2ServiceInterface, error) {
+	cfg, err := newAWSConfigV2(ctx, secretsCache, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return services.NewEC2Service(cfg), err
+}
+
+// StartEKSService initializes and returns an instance of the EKSServiceInterface
+// interface, which provides methods for interacting with the EKS service in AWS.
+func StartEKSService(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (services.EKSServiceInterface, error) {
+	cfg, err := newAWSConfigV2(ctx, secretsCache, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	return services.NewEKSService(cfg), err
+}
 
 // NodeGroupIssueIsUpdatable checks to see the node group can be updated with the given issue code.
 func NodeGroupIssueIsUpdatable(code string) bool {


### PR DESCRIPTION
Issue: https://github.com/rancher/eks-operator/issues/336

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
