### PR TITLE
[v2.9] Avoid using secretsCache for secrets

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -84,7 +84,7 @@ func (h *Handler) OnEksConfigChanged(_ string, config *eksv1.EKSClusterConfig) (
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	awsSVCs, err := newAWSv2Services(ctx, h.secretsCache, config.Spec)
+	awsSVCs, err := newAWSv2Services(ctx, h.secrets, config.Spec)
 	if err != nil {
 		return config, fmt.Errorf("error creating new AWS services: %w", err)
 	}
@@ -207,7 +207,7 @@ func (h *Handler) OnEksConfigRemoved(_ string, config *eksv1.EKSClusterConfig) (
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	awsSVCs, err := newAWSv2Services(ctx, h.secretsCache, config.Spec)
+	awsSVCs, err := newAWSv2Services(ctx, h.secrets, config.Spec)
 	if err != nil {
 		return config, fmt.Errorf("error creating new AWS services: %w", err)
 	}

--- a/controller/external.go
+++ b/controller/external.go
@@ -19,8 +19,8 @@ import (
 
 // StartEC2Service initializes and returns an instance of the EC2ServiceInterface
 // interface, which provides methods for interacting with the EC2 service in AWS.
-func StartEC2Service(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (services.EC2ServiceInterface, error) {
-	cfg, err := newAWSConfigV2(ctx, secretsCache, spec)
+func StartEC2Service(ctx context.Context, secretClient wranglerv1.SecretClient, spec eksv1.EKSClusterConfigSpec) (services.EC2ServiceInterface, error) {
+	cfg, err := newAWSConfigV2(ctx, secretClient, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -30,8 +30,8 @@ func StartEC2Service(ctx context.Context, secretsCache wranglerv1.SecretCache, s
 
 // StartEKSService initializes and returns an instance of the EKSServiceInterface
 // interface, which provides methods for interacting with the EKS service in AWS.
-func StartEKSService(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (services.EKSServiceInterface, error) {
-	cfg, err := newAWSConfigV2(ctx, secretsCache, spec)
+func StartEKSService(ctx context.Context, secretClient wranglerv1.SecretClient, spec eksv1.EKSClusterConfigSpec) (services.EKSServiceInterface, error) {
+	cfg, err := newAWSConfigV2(ctx, secretClient, spec)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/internal.go
+++ b/controller/internal.go
@@ -12,9 +12,10 @@ import (
 	"github.com/rancher/eks-operator/pkg/eks/services"
 	"github.com/rancher/eks-operator/utils"
 	wranglerv1 "github.com/rancher/wrangler/v2/pkg/generated/controllers/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func newAWSConfigV2(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (aws.Config, error) {
+func newAWSConfigV2(ctx context.Context, secretClient wranglerv1.SecretClient, spec eksv1.EKSClusterConfigSpec) (aws.Config, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return cfg, fmt.Errorf("error loading default AWS config: %w", err)
@@ -26,7 +27,7 @@ func newAWSConfigV2(ctx context.Context, secretsCache wranglerv1.SecretCache, sp
 
 	if amazonCredentialSecret := spec.AmazonCredentialSecret; amazonCredentialSecret != "" {
 		ns, id := utils.Parse(spec.AmazonCredentialSecret)
-		secret, err := secretsCache.Get(ns, id)
+		secret, err := secretClient.Get(ns, id, metav1.GetOptions{})
 		if err != nil {
 			return cfg, fmt.Errorf("error getting secret %s/%s: %w", ns, id, err)
 		}
@@ -46,8 +47,8 @@ func newAWSConfigV2(ctx context.Context, secretsCache wranglerv1.SecretCache, sp
 	return cfg, nil
 }
 
-func newAWSv2Services(ctx context.Context, secretsCache wranglerv1.SecretCache, spec eksv1.EKSClusterConfigSpec) (*awsServices, error) {
-	cfg, err := newAWSConfigV2(ctx, secretsCache, spec)
+func newAWSv2Services(ctx context.Context, secretClient wranglerv1.SecretClient, spec eksv1.EKSClusterConfigSpec) (*awsServices, error) {
+	cfg, err := newAWSConfigV2(ctx, secretClient, spec)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We would like to avoid using secretsCache, because cache might be outdated. Secrets are considered sensitive and we might want to always see the latest changes.

Issue: https://github.com/rancher/aks-operator/issues/159 (cherry picked from commit d83f728836d53788c4af23abe80fd473d4767f2c)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
