### PR TITLE
[v2.8] Prevent duplicated node group names

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -384,8 +384,15 @@ func validateUpdate(config *eksv1.EKSClusterConfig) error {
 	}
 
 	errs := make([]string, 0)
+	nodeGroupNames := make(map[string]struct{}, 0)
 	// validate nodegroup versions
 	for _, ng := range config.Spec.NodeGroups {
+		if _, ok := nodeGroupNames[aws.StringValue(ng.NodegroupName)]; !ok {
+			nodeGroupNames[aws.StringValue(ng.NodegroupName)] = struct{}{}
+		} else {
+			errs = append(errs, fmt.Sprintf("node group names must be unique within the [%s] cluster to avoid duplication", config.Name))
+		}
+
 		if ng.Version == nil {
 			continue
 		}
@@ -552,7 +559,7 @@ func (h *Handler) validateCreate(config *eksv1.EKSClusterConfig, awsSVCs *awsSer
 				return fmt.Errorf(cannotBeNilError, "name", *ng.NodegroupName, config.Name)
 			}
 			if nodeP[*ng.NodegroupName] {
-				return fmt.Errorf("NodePool names must be unique within the [%s] cluster to avoid duplication", config.Name)
+				return fmt.Errorf("node group names must be unique within the [%s] cluster to avoid duplication", config.Name)
 			}
 			nodeP[*ng.NodegroupName] = true
 			if ng.Version == nil {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
Added a validation check to prevent duplicated node group names during an update. I've also updated the relevant error string returned during creation to match EKS terminology (node groups) and Go style guidelines (lowercase).

**Which issue(s) this PR fixes**
Issue #221 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
