### PR TITLE
chore: make dependabot ignore all k8s updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,7 +23,7 @@ updates:
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   - dependency-name: "go.etcd.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
@@ -51,7 +51,7 @@ updates:
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   - dependency-name: "go.etcd.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
@@ -81,7 +81,7 @@ updates:
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   - dependency-name: "go.etcd.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler
@@ -111,7 +111,7 @@ updates:
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
-    update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
+    update-types: [ "version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch" ]
   - dependency-name: "go.etcd.io/*"
     update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   # Ignore wrangler


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot is ignoring updates for k8s dependencies but only for major and minor versions. As k8s is updated manually in sync with Rancher core, we also need to ignore patch releases.

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
