### PR TITLE
fix: Replace unapproved GH Actions with approved ones

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -11,4 +11,5 @@ jobs:
     - uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
-    - uses: joelanford/go-apidiff@main
+    - name: Generate API diff
+      run: make apidiff

--- a/.github/workflows/e2e-branch.yaml
+++ b/.github/workflows/e2e-branch.yaml
@@ -68,10 +68,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: "v0.16.0"
-          skipClusterCreation: "true"
+          version: v0.23.0
+          install_only: true
       - name: Create kind cluster
         run: make setup-kind
       - name: E2E tests

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,6 @@ jobs:
         with:
           go-version: 1.21.x
       - name: Analysis
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           args: -v
-          skip-pkg-cache: true

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -49,18 +49,18 @@ jobs:
           path: charts
       - name: Run release script
         run: ./eks-operator/.github/scripts/update-rancher-charts.sh ${{github.event.inputs.prev_eks_operator}} ${{github.event.inputs.new_eks_operator}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/charts
-          title: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}}'
-          body: |
-            Update EKS operator to v${{github.event.inputs.new_eks_operator}}
-
-            Changelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks_operator}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.charts_ref}}
-          path: ./charts/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'highlander-ci-bot/charts:${{github.event.inputs.new_eks_operator}}-$TIMESTAMP',
+              base: ${{github.event.inputs.charts_ref}},
+              title: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}}',
+              body: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}}\n\nChangelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks_operator}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -41,18 +41,18 @@ jobs:
           go-version: ${{ env.SETUP_GO_VERSION }}
       - name: Run release script
         run: ./eks-operator/.github/scripts/update-rancher-dep.sh ${{github.event.inputs.new_eks}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/rancher
-          title: ' Update EKS operator to v${{github.event.inputs.new_eks}}'
-          body: |
-            Update EKS operator to v${{github.event.inputs.new_eks}}
-
-            Changelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.rancher_ref}}
-          path: ./rancher/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: 'highlander-ci-bot/rancher:${{github.event.inputs.new_eks}}-$TIMESTAMP',
+              base: ${{github.event.inputs.rancher_ref}},
+              title: 'Update EKS operator to v${{github.event.inputs.new_eks}}',
+              body: 'Update EKS operator to v${{github.event.inputs.new_eks}}\n\nChangelog:https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks}}\n\ncc @rancher/highlander'
+            })

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,10 @@ GINKGO_VER := v2.17.2
 GINKGO_BIN := ginkgo
 GINKGO := $(BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
+GO_APIDIFF_VER := v0.8.2
+GO_APIDIFF_BIN := go-apidiff
+GO_APIDIFF := $(BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER)
+
 SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER)
@@ -63,6 +67,9 @@ $(MOCKGEN):
 
 $(GINKGO):
 	GOBIN=$(BIN_DIR) $(GO_INSTALL) github.com/onsi/ginkgo/v2/ginkgo $(GINKGO_BIN) $(GINKGO_VER)
+
+$(GO_APIDIFF):
+	GOBIN=$(BIN_DIR) $(GO_INSTALL) github.com/joelanford/go-apidiff $(GO_APIDIFF_BIN) $(GO_APIDIFF_VER)
 
 $(SETUP_ENVTEST): 
 	GOBIN=$(BIN_DIR) $(GO_INSTALL) sigs.k8s.io/controller-runtime/tools/setup-envtest $(SETUP_ENVTEST_BIN) $(SETUP_ENVTEST_VER)
@@ -175,3 +182,9 @@ docker-build-e2e:
 .PHOHY: delete-local-kind-cluster
 delete-local-kind-cluster: ## Delete the local kind cluster
 	kind delete cluster --name=$(CLUSTER_NAME)
+
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
+
+.PHONY: apidiff
+apidiff: $(GO_APIDIFF) ## Check for API differences
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Replace unapproved GH Actions with approved ones. To [enhance security](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), the 3rd-party GH Action used to install kind is pinned to a commit SHA. Note that dependabot will [update](https://github.com/dependabot/dependabot-core/issues/4691) both the commit SHA and the human-readable value next to it.

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/highlander/issues/89

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [x] backport needed 
