### PR TITLE
[v2.9] fix: Replace unapproved GH Actions with approved ones

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -8,7 +8,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
-    - uses: joelanford/go-apidiff@main
+    - name: Generate API diff
+      run: make apidiff

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
       - name: Build

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -58,13 +58,13 @@ jobs:
             COMMITDATE=${{ steps.export_tag.outputs.commit_date }}
             COMMIT=${{ github.sha }}
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-      - uses: engineerd/setup-kind@v0.5.0
+      - uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
         with:
-          version: "v0.16.0"
-          skipClusterCreation: "true"
+          version: v0.23.0
+          install_only: true
       - name: Create kind cluster
         run: make setup-kind
       - name: E2E tests

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,11 +13,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
       - name: Analysis
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1
         with:
           args: -v
-          skip-pkg-cache: true

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
     - name: Run tests

--- a/.github/workflows/update-rancher-charts.yaml
+++ b/.github/workflows/update-rancher-charts.yaml
@@ -5,13 +5,13 @@ on:
       ref:
         description: "Branch to use for GitHub action workflow"
         required: true
-        default: "main"
+        default: "release-v2.9"
       charts_ref:
         description: "Submit PR against the following rancher/charts branch (e.g. dev-v2.7)"
         required: true
-        default: "dev-v2.7"
+        default: "dev-v2.9"
       prev_eks_operator:
-        description: "Previous EKS operator version (e.g. 1.1.0-rc2)"
+        description: "Previous EKS operator version (e.g. 1.2.0-rc.1)"
         required: true
         default: ""
       new_eks_operator:
@@ -40,6 +40,7 @@ jobs:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: eks-operator
+          persist-credentials: false
       - name: Checkout rancher/charts
         uses: actions/checkout@v4
         with:
@@ -47,20 +48,28 @@ jobs:
           repository: rancher/charts
           ref: ${{github.event.inputs.charts_ref}}
           path: charts
-      - name: Run release script
+          persist-credentials: false
+      - name: Run release script # release script is responsible for git add/commit
         run: ./eks-operator/.github/scripts/update-rancher-charts.sh ${{github.event.inputs.prev_eks_operator}} ${{github.event.inputs.new_eks_operator}} ${{github.event.inputs.prev_chart}}  ${{github.event.inputs.new_chart}}  ${{github.event.inputs.should_replace}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/charts.git
+          git push bot-fork HEAD:${{github.event.inputs.new_eks_operator}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/charts
-          title: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}}'
-          body: |
-            Update EKS operator to v${{github.event.inputs.new_eks_operator}}
-
-            Changelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks_operator}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.charts_ref}}
-          path: ./charts/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'charts',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_eks_operator}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.charts_ref}},
+              title: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}}',
+              body: 'Update EKS operator to v${{github.event.inputs.new_eks_operator}\n\nChangelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks_operator}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -29,6 +29,7 @@ jobs:
           fetch-depth: 0
           ref: ${{github.event.inputs.ref}}
           path: eks-operator
+          persist-credentials: false
       - name: Checkout rancher/rancher
         uses: actions/checkout@v4
         with:
@@ -36,23 +37,31 @@ jobs:
           repository: rancher/rancher
           ref: ${{github.event.inputs.rancher_ref}}
           path: rancher
-      - uses: actions/setup-go@v4
+          persist-credentials: false
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.SETUP_GO_VERSION }}
-      - name: Run release script
+      - name: Run release script # release script is responsible for git add/commit
         run: ./eks-operator/.github/scripts/update-rancher-dep.sh ${{github.event.inputs.new_eks}}
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v5
+      - name: Set timestamp
+        run: echo "TIMESTAMP=$(date +'%s')" >> "$GITHUB_ENV"
+      - name: Push changes
+        env:
+          USERNAME: highlander-ci-bot
+          TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+        run: |
+          git remote add bot-fork https://${USERNAME}:${TOKEN}@github.com/highlander-ci-bot/rancher.git
+          git push bot-fork HEAD:${{github.event.inputs.new_eks}}-${{env.TIMESTAMP}}
+      - name: Create PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          token: ${{secrets.CI_BOT_TOKEN}}
-          push-to-fork: highlander-ci-bot/rancher
-          title: ' Update EKS operator to v${{github.event.inputs.new_eks}}'
-          body: |
-            Update EKS operator to v${{github.event.inputs.new_eks}}
-
-            Changelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks}}
-
-            cc @rancher/highlander
-          branch-suffix: timestamp
-          base: ${{github.event.inputs.rancher_ref}}
-          path: ./rancher/
+          github-token: ${{secrets.CI_BOT_TOKEN}}
+          script: |
+            github.pulls.create({
+              owner: 'rancher',
+              repo: 'rancher',
+              head: 'highlander-ci-bot:${{github.event.inputs.new_eks}}-${{env.TIMESTAMP}}',
+              base: ${{github.event.inputs.rancher_ref}},
+              title: 'Update EKS operator to v${{github.event.inputs.new_eks}}',
+              body: 'Update EKS operator to v${{github.event.inputs.new_eks}}\n\nChangelog: https://github.com/rancher/eks-operator/releases/tag/v${{github.event.inputs.new_eks}}\n\ncc @rancher/highlander'
+            })

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21.x
     - name: Run make verify

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ GINKGO_VER := v2.17.2
 GINKGO_BIN := ginkgo
 GINKGO := $(BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
+GO_APIDIFF_VER := v0.8.2
+GO_APIDIFF_BIN := go-apidiff
+GO_APIDIFF := $(BIN_DIR)/$(GO_APIDIFF_BIN)-$(GO_APIDIFF_VER)
+
 SETUP_ENVTEST_VER := v0.0.0-20211110210527-619e6b92dab9
 SETUP_ENVTEST_BIN := setup-envtest
 SETUP_ENVTEST := $(BIN_DIR)/$(SETUP_ENVTEST_BIN)-$(SETUP_ENVTEST_VER)
@@ -172,3 +176,9 @@ docker-build-e2e:
 .PHOHY: delete-local-kind-cluster
 delete-local-kind-cluster: ## Delete the local kind cluster
 	kind delete cluster --name=$(CLUSTER_NAME)
+
+APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/release-v2.9)
+
+.PHONY: apidiff
+apidiff: $(GO_APIDIFF) ## Check for API differences
+	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Replace unapproved GH Actions with approved ones. To [enhance security](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), the 3rd-party GH Action used to install kind is pinned to a commit SHA. Note that dependabot will [update](https://github.com/dependabot/dependabot-core/issues/4691) both the commit SHA and the human-readable value next to it.

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/highlander/issues/89

**Special notes for your reviewer**:
- actions/checkout has been updated to v4 to eliminate Node runtime version warnings
 - actions/setup-go has been updated to v5 to eliminate Node runtime version warnings
 - Upon checkout, credentials are not being persisted since the git commands will occur on a different repo (bot's fork)


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
