### PR TITLE
[v2.9] Change default AMI type to Amazon Linux 2023

### DIFF
--- a/controller/external.go
+++ b/controller/external.go
@@ -196,11 +196,13 @@ func BuildUpstreamClusterState(ctx context.Context, name, managedTemplateID stri
 				ngToAdd.Ec2SshKey = ng.Nodegroup.RemoteAccess.Ec2SshKey
 			}
 		}
+		// TODO: Update AMITypesAl2X8664Gpu to Amazon Linux 2023 when it is available
+		// Issue https://github.com/rancher/eks-operator/issues/568
 		if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2X8664Gpu {
 			ngToAdd.Gpu = aws.Bool(true)
-		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2X8664 {
+		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023X8664Standard {
 			ngToAdd.Gpu = aws.Bool(false)
-		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2Arm64 {
+		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023Arm64Standard {
 			ngToAdd.Arm = aws.Bool(true)
 		}
 		upstreamSpec.NodeGroups = append(upstreamSpec.NodeGroups, ngToAdd)

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -279,11 +279,11 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 		if opts.NodeGroup.LaunchTemplate != nil {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesCustom
 		} else if arm := opts.NodeGroup.Arm; aws.ToBool(arm) {
-			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2Arm64
+			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023Arm64Standard
 		} else if gpu := opts.NodeGroup.Gpu; aws.ToBool(gpu) {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2X8664Gpu
 		} else {
-			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2X8664
+			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023X8664Standard
 		}
 	}
 

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -1012,7 +1012,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
 			Subnets:       createNodeGroupOpts.NodeGroup.Subnets,
 			NodeRole:      aws.String("test"),
-			AmiType:       ekstypes.AMITypesAl2Arm64,
+			AmiType:       ekstypes.AMITypesAl2023Arm64Standard,
 		}).Return(nil, nil)
 
 		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(ctx, createNodeGroupOpts)
@@ -1066,7 +1066,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
 			Subnets:       createNodeGroupOpts.NodeGroup.Subnets,
 			NodeRole:      aws.String("test"),
-			AmiType:       ekstypes.AMITypesAl2X8664,
+			AmiType:       ekstypes.AMITypesAl2023X8664Standard,
 		}).Return(nil, nil)
 
 		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(ctx, createNodeGroupOpts)


### PR DESCRIPTION
Amazon Linux 2 end of support date is 2025-06-30,
This change is updating AMI to Amazon Linux 2023.

Issue: https://github.com/rancher/eks-operator/issues/568 (cherry picked from commit fb28a54c64a44290b3b2f6650c9948eabc3b4bda)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
