### PR TITLE
[v2.9] Fix logging types updates

### DIFF
--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -191,12 +191,16 @@ func getLoggingTypesUpdate(loggingTypes []string, upstreamLoggingTypes []string)
 
 	if len(loggingTypes) > 0 {
 		loggingTypesToDisable := getLoggingTypesToDisable(loggingTypes, upstreamLoggingTypes)
-		loggingUpdate.ClusterLogging = append(loggingUpdate.ClusterLogging, loggingTypesToDisable)
+		if loggingTypesToDisable.Enabled != nil {
+			loggingUpdate.ClusterLogging = append(loggingUpdate.ClusterLogging, loggingTypesToDisable)
+		}
 	}
 
 	if len(upstreamLoggingTypes) > 0 {
 		loggingTypesToEnable := getLoggingTypesToEnable(loggingTypes, upstreamLoggingTypes)
-		loggingUpdate.ClusterLogging = append(loggingUpdate.ClusterLogging, loggingTypesToEnable)
+		if loggingTypesToEnable.Enabled != nil {
+			loggingUpdate.ClusterLogging = append(loggingUpdate.ClusterLogging, loggingTypesToEnable)
+		}
 	}
 
 	if len(loggingUpdate.ClusterLogging) > 0 {

--- a/pkg/eks/update_test.go
+++ b/pkg/eks/update_test.go
@@ -200,11 +200,11 @@ var _ = Describe("UpdateLoggingTypes", func() {
 			EKSService: eksServiceMock,
 			Config: &eksv1.EKSClusterConfig{
 				Spec: eksv1.EKSClusterConfigSpec{
-					LoggingTypes: []string{"test1", "test2", "test3-enabled"},
+					LoggingTypes: []string{"audit", "authenticator", "controllerManager"},
 				},
 			},
 			UpstreamClusterSpec: &eksv1.EKSClusterConfigSpec{
-				LoggingTypes: []string{"test1", "test2", "disabled"},
+				LoggingTypes: []string{"audit", "authenticator", "scheduler"},
 			},
 		}
 	})
@@ -221,11 +221,11 @@ var _ = Describe("UpdateLoggingTypes", func() {
 					ClusterLogging: []ekstypes.LogSetup{
 						{
 							Enabled: aws.Bool(false),
-							Types:   utils.ConvertToLogTypes([]string{"disabled"}),
+							Types:   utils.ConvertToLogTypes([]string{"scheduler"}),
 						},
 						{
 							Enabled: aws.Bool(true),
-							Types:   utils.ConvertToLogTypes([]string{"test3-enabled"}),
+							Types:   utils.ConvertToLogTypes([]string{"controllerManager"}),
 						},
 					},
 				},
@@ -233,6 +233,23 @@ var _ = Describe("UpdateLoggingTypes", func() {
 		).Return(nil, nil)
 		updated, err := UpdateClusterLoggingTypes(ctx, updateLoggingTypesOpts)
 		Expect(updated).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("shouldn't update cluster logging types when no changes", func() {
+		updateLoggingTypesOpts = &UpdateLoggingTypesOpts{
+			EKSService: eksServiceMock,
+			Config: &eksv1.EKSClusterConfig{
+				Spec: eksv1.EKSClusterConfigSpec{
+					LoggingTypes: []string{"audit", "authenticator", "scheduler", "controllerManager"},
+				},
+			},
+			UpstreamClusterSpec: &eksv1.EKSClusterConfigSpec{
+				LoggingTypes: []string{"audit", "authenticator", "scheduler", "controllerManager"},
+			},
+		}
+		updated, err := UpdateClusterLoggingTypes(ctx, updateLoggingTypesOpts)
+		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
Update getLoggingTypesUpdate function when there are no changes for logging types. Adding also test scenario to avoid regressions in the future.

Issue: https://github.com/rancher/eks-operator/issues/546 (cherry picked from commit 39a79aece7669301c072819293ae052cfcab5868)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
