### PR TITLE
ci: Remove e2e tests for 2.7

### DIFF
--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -36,14 +36,3 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  e2e-test-v2_7:
-    if: ${{ always() }}
-    needs: [ e2e-test-main, e2e-test-v2_9, e2e-test-v2_8 ]
-    uses: ./.github/workflows/e2e-branch.yaml
-    with:
-      branch: release-v2.7
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_REGION: ${{ secrets.AWS_REGION }}
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   amazonCredentialSecret: default:aws-credentials
   imported: false
   kmsKey: ""
-  kubernetesVersion: "1.26"
+  kubernetesVersion: "1.28"
   loggingTypes: []
   nodeGroups:
   - desiredSize: 2
@@ -27,7 +27,7 @@ spec:
     subnets: []
     tags: {}
     userData: ""
-    version: "1.26"
+    version: "1.28"
   privateAccess: false
   publicAccess: true
   publicAccessSources: []


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

Removed e2e tests for 2.7. Also bumped the version of k8s used in the e2e test to 1.28.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
