### PR TITLE
[v2.9] fix: Bump k8s version used in e2e test

### DIFF
--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-KUBE_VERSION="${KUBE_VERSION:-v1.26.3}"
+KUBE_VERSION="${KUBE_VERSION:-v1.28.9}"
 CLUSTER_NAME="${CLUSTER_NAME:-eks-operator-e2e}"
 
 if ! kind get clusters | grep "$CLUSTER_NAME"; then

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   amazonCredentialSecret: default:aws-credentials
   imported: false
   kmsKey: ""
-  kubernetesVersion: "1.26"
+  kubernetesVersion: "1.28"
   loggingTypes: []
   nodeGroups:
   - desiredSize: 2
@@ -27,7 +27,7 @@ spec:
     subnets: []
     tags: {}
     userData: ""
-    version: "1.26"
+    version: "1.28"
   privateAccess: false
   publicAccess: true
   publicAccessSources: []


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump k8s version used in e2e test to 1.28.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
