### PR TITLE
[v2.8] fix: Use version v2.8-head of Rancher for e2e tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-v2.8
     tags:
       - 'v*'
 jobs:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-v2.8
     tags:
       - 'v*'
 jobs:

--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-v2.8
     tags:
       - "v*"
 jobs:

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-v2.8
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-v2.8
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,6 +8,6 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.11.1
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.2
-rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
+rancherVersion: v2.8-head
+rancherChartURL: https://releases.rancher.com/server-charts/latest/
 


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates the e2e tests for `release-v2.8` to use the latest Rancher Helm chart (currently `2.8.5`) and overrides the image tag with `v2.8-head`. It also updates the CI workflows to run against `release-v2.8` upon push.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
