### PR TITLE
[v2.9] Disable all logging types when empty

### DIFF
--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -189,7 +189,7 @@ func UpdateNodegroupVersion(ctx context.Context, opts *UpdateNodegroupVersionOpt
 func getLoggingTypesUpdate(loggingTypes []string, upstreamLoggingTypes []string) *ekstypes.Logging {
 	loggingUpdate := &ekstypes.Logging{}
 
-	if len(loggingTypes) > 0 {
+	if len(loggingTypes) >= 0 {
 		loggingTypesToDisable := getLoggingTypesToDisable(loggingTypes, upstreamLoggingTypes)
 		if loggingTypesToDisable.Enabled != nil {
 			loggingUpdate.ClusterLogging = append(loggingUpdate.ClusterLogging, loggingTypesToDisable)


### PR DESCRIPTION
Disable all logging types when option loggingTypes is empty. Adding also test coverage to avoid regressions.

Issue: https://github.com/rancher/eks-operator/issues/673 (cherry picked from commit 8f098a44862c89619be10741c5025f425ebabb64)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
