### PR TITLE
Revert "Merge pull request #790 from mjura/gpu-v2.9"

### DIFF
--- a/controller/external.go
+++ b/controller/external.go
@@ -207,8 +207,9 @@ func BuildUpstreamClusterState(ctx context.Context, name, managedTemplateID stri
 				ngToAdd.Ec2SshKey = ng.Nodegroup.RemoteAccess.Ec2SshKey
 			}
 		}
-
-		if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023X8664Nvidia {
+		// TODO: Update AMITypesAl2X8664Gpu to Amazon Linux 2023 when it is available
+		// Issue https://github.com/rancher/eks-operator/issues/568
+		if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2X8664Gpu {
 			ngToAdd.Gpu = aws.Bool(true)
 		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023X8664Standard {
 			ngToAdd.Gpu = aws.Bool(false)

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -282,7 +282,7 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 		} else if arm := opts.NodeGroup.Arm; aws.ToBool(arm) {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023Arm64Standard
 		} else if gpu := opts.NodeGroup.Gpu; aws.ToBool(gpu) {
-			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023X8664Nvidia
+			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2X8664Gpu
 		} else {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023X8664Standard
 		}

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -956,7 +956,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
 			Subnets:       createNodeGroupOpts.NodeGroup.Subnets,
 			NodeRole:      aws.String("test"),
-			AmiType:       ekstypes.AMITypesAl2023X8664Nvidia,
+			AmiType:       ekstypes.AMITypesAl2X8664Gpu,
 		}).Return(nil, nil)
 
 		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(ctx, createNodeGroupOpts)


### PR DESCRIPTION
This reverts commit bb73bdb6605f0485acd51bda9801ab40ce6e2538, reversing changes made to 2fffed6c5e96d8ad36154f8ad419a029fbca486f.

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

It looks like the new GPU AMI is still [not available](https://github.com/rancher/eks-operator/issues/568#issuecomment-2340718035).

**Which issue(s) this PR fixes**
Issue #568 

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
