### PR TITLE
[v2.7] Bump Go to 1.20.14

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,4 @@
  Requires upgrading to Go 1.21 but we can't do this before Rancher v2.7 gets updated 
 CVE-2023-45288
 CVE-2024-24790
+CVE-2024-34156

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -8,7 +8,7 @@ RUN zypper -n update && \
 
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN curl -sLf https://storage.googleapis.com/golang/go1.19.3.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
+RUN curl -sLf https://storage.googleapis.com/golang/go1.20.14.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
 # workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
 RUN if [ "${ARCH}" == "arm64" ]; then \
         zypper -n install binutils-gold ; \

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -407,7 +408,7 @@ func validateUpdate(config *eksv1.EKSClusterConfig) error {
 			"must be equal to or one minor version lower than the cluster kubernetes version", aws.StringValue(config.Spec.KubernetesVersion), aws.StringValue(ng.Version)))
 	}
 	if len(errs) != 0 {
-		return fmt.Errorf(strings.Join(errs, ";"))
+		return errors.New(strings.Join(errs, ";"))
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Although the Go module version for release-v2.7 is set to 1.20, we used 1.19 to compile it. Bumping the Go version helps mitigate against vulnerabilities present in 1.19 but addressed in 1.20.

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
