### PR TITLE
[v2.10] Bump AMI Amazon Linux 2023 with Nvidia support

### DIFF
--- a/controller/external.go
+++ b/controller/external.go
@@ -207,9 +207,7 @@ func BuildUpstreamClusterState(ctx context.Context, name, managedTemplateID stri
 				ngToAdd.Ec2SshKey = ng.Nodegroup.RemoteAccess.Ec2SshKey
 			}
 		}
-		// TODO: Update AMITypesAl2X8664Gpu to Amazon Linux 2023 when it is available
-		// Issue https://github.com/rancher/eks-operator/issues/568
-		if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2X8664Gpu {
+		if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023X8664Nvidia {
 			ngToAdd.Gpu = aws.Bool(true)
 		} else if ng.Nodegroup.AmiType == ekstypes.AMITypesAl2023X8664Standard {
 			ngToAdd.Gpu = aws.Bool(false)

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -282,7 +282,7 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 		} else if arm := opts.NodeGroup.Arm; aws.ToBool(arm) {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023Arm64Standard
 		} else if gpu := opts.NodeGroup.Gpu; aws.ToBool(gpu) {
-			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2X8664Gpu
+			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023X8664Nvidia
 		} else {
 			nodeGroupCreateInput.AmiType = ekstypes.AMITypesAl2023X8664Standard
 		}

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -956,7 +956,7 @@ var _ = Describe("CreateNodeGroup", func() {
 			InstanceTypes: createNodeGroupOpts.NodeGroup.SpotInstanceTypes,
 			Subnets:       createNodeGroupOpts.NodeGroup.Subnets,
 			NodeRole:      aws.String("test"),
-			AmiType:       ekstypes.AMITypesAl2X8664Gpu,
+			AmiType:       ekstypes.AMITypesAl2023X8664Nvidia,
 		}).Return(nil, nil)
 
 		launchTemplateVersion, generatedNodeRole, err := CreateNodeGroup(ctx, createNodeGroupOpts)


### PR DESCRIPTION
Bump AMI Amazon Linux 2023 with Nvidia support

(cherry picked from commit 824e7bb30f5914b8ca4d36e69df7cb6a696bcd21)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #568 

**Special notes for your reviewer**:

There was a mistake and a previous [PR](https://github.com/rancher/eks-operator/pull/988) was targeting `main` instead of `release-v2.10`

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
