### PR TITLE
Prevent panic on no launch template ID

### DIFF
--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -320,7 +320,7 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 	}
 
 	_, err = opts.EKSService.CreateNodegroup(ctx, nodeGroupCreateInput)
-	if err != nil {
+	if err != nil && lt.ID != nil {
 		// If there was an error creating the node group, then the template version should be deleted
 		// to prevent many launch template versions from being created before the issue is fixed.
 		DeleteLaunchTemplateVersions(ctx, opts.EC2Service, *lt.ID, []*string{launchTemplateVersion})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/eks-operator/issues/986

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
