### PR TITLE
[main] handle conflict errors while updating eksClusterConfig

### DIFF
--- a/controller/eks-cluster-config-handler_test.go
+++ b/controller/eks-cluster-config-handler_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
 	"github.com/rancher/eks-operator/pkg/eks"
@@ -219,5 +222,88 @@ var _ = Describe("updateCluster", func() {
 		_, err := handler.OnEksConfigChanged("", eksConfig)
 		Expect(err).To(MatchError("versions for cluster [1.25] and node group [1.21] are not compatible: " +
 			"the node group version may only be up to three minor versions older than the cluster version"))
+	})
+})
+
+var _ = Describe("recordError", func() {
+	var (
+		eksConfig *eksv1.EKSClusterConfig
+		handler   *Handler
+	)
+
+	BeforeEach(func() {
+		eksConfig = &eksv1.EKSClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testrecorderror",
+				Namespace: "default",
+			},
+			Spec: eksv1.EKSClusterConfigSpec{
+				DisplayName:         "test",
+				Region:              "test",
+				PrivateAccess:       aws.Bool(true),
+				PublicAccess:        aws.Bool(true),
+				PublicAccessSources: []string{"test"},
+				Tags:                map[string]string{"test": "test"},
+				LoggingTypes:        []string{"test"},
+				KubernetesVersion:   aws.String("test"),
+				SecretsEncryption:   aws.Bool(true),
+				KmsKey:              aws.String("test"),
+			},
+		}
+
+		Expect(cl.Create(ctx, eksConfig)).To(Succeed())
+	})
+
+	It("should return same conflict error when onChange returns a conflict error", func() {
+		oldOutput := logrus.StandardLogger().Out
+		buf := bytes.Buffer{}
+		logrus.SetOutput(&buf)
+
+		eksConfigUpdated := eksConfig.DeepCopy()
+		Expect(cl.Update(ctx, eksConfigUpdated)).To(Succeed())
+
+		var expectedErr error
+		expectedConfig := &eksv1.EKSClusterConfig{}
+		onChange := func(key string, config *eksv1.EKSClusterConfig) (*eksv1.EKSClusterConfig, error) {
+			expectedErr = cl.Update(ctx, config)
+			return expectedConfig, expectedErr
+		}
+
+		eksConfig.ResourceVersion = "1"
+		handleFunction := handler.recordError(onChange)
+		config, err := handleFunction("", eksConfig)
+
+		Expect(config).To(Equal(expectedConfig))
+		Expect(err).To(Equal(expectedErr))
+		Expect("").To(Equal(string(buf.Bytes())))
+		logrus.SetOutput(oldOutput)
+	})
+
+	It("should return same conflict error when onChange returns a conflict error and print a debug log for the error", func() {
+		oldOutput := logrus.StandardLogger().Out
+		buf := bytes.Buffer{}
+		logrus.SetOutput(&buf)
+		logrus.SetLevel(logrus.DebugLevel)
+
+		eksConfigUpdated := eksConfig.DeepCopy()
+		Expect(cl.Update(ctx, eksConfigUpdated)).To(Succeed())
+
+		var expectedErr error
+		expectedConfig := &eksv1.EKSClusterConfig{}
+		onChange := func(key string, config *eksv1.EKSClusterConfig) (*eksv1.EKSClusterConfig, error) {
+			expectedErr = cl.Update(ctx, config)
+			return expectedConfig, expectedErr
+		}
+
+		eksConfig.ResourceVersion = "1"
+		handleFunction := handler.recordError(onChange)
+		config, err := handleFunction("", eksConfig)
+
+		Expect(config).To(Equal(expectedConfig))
+		Expect(err).To(MatchError(expectedErr))
+
+		cleanLogOutput := strings.Replace(string(buf.Bytes()), `\"`, `"`, -1)
+		Expect(strings.Contains(cleanLogOutput, err.Error())).To(BeTrue())
+		logrus.SetOutput(oldOutput)
 	})
 })


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
in case a conflict error occurs the controller's recordError Function will just print it and return the error as it is.

conflict errors occur since rancher also modifies eksconfig object. As conflict error returns empty object, errors like `"Error recording ekscc [] failure message: resource name may not be empty"` occurs when we try to add a failure message to eksconfig status and update it.
The operation which results in conflict gets applied automatically in the next reconciliation call of the controller hence it is safe to just log it. 

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue # https://github.com/rancher/eks-operator/issues/1009

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
- [X] backport needed 
