### PR TITLE
[main] check upstream cluster updates when updating the cluster

### DIFF
--- a/charts/eks-operator-crd/templates/crds.yaml
+++ b/charts/eks-operator-crd/templates/crds.yaml
@@ -179,6 +179,12 @@ spec:
             type: object
           status:
             properties:
+              completedUpdateIDs:
+                items:
+                  nullable: true
+                  type: string
+                nullable: true
+                type: array
               failureMessage:
                 nullable: true
                 type: string

--- a/pkg/apis/eks.cattle.io/v1/types.go
+++ b/pkg/apis/eks.cattle.io/v1/types.go
@@ -61,9 +61,10 @@ type EKSClusterConfigStatus struct {
 	ManagedLaunchTemplateVersions map[string]string `json:"managedLaunchTemplateVersions"`
 	TemplateVersionsToDelete      []string          `json:"templateVersionsToDelete"`
 	// describes how the above network fields were provided. Valid values are provided and generated
-	NetworkFieldsSource string `json:"networkFieldsSource"`
-	FailureMessage      string `json:"failureMessage"`
-	GeneratedNodeRole   string `json:"generatedNodeRole"`
+	NetworkFieldsSource string   `json:"networkFieldsSource"`
+	FailureMessage      string   `json:"failureMessage"`
+	GeneratedNodeRole   string   `json:"generatedNodeRole"`
+	CompletedUpdateIDs  []string `json:"completedUpdateIDs,omitempty"`
 }
 
 type NodeGroup struct {

--- a/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/eks.cattle.io/v1/zz_generated_deepcopy.go
@@ -196,6 +196,11 @@ func (in *EKSClusterConfigStatus) DeepCopyInto(out *EKSClusterConfigStatus) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.CompletedUpdateIDs != nil {
+		in, out := &in.CompletedUpdateIDs, &out.CompletedUpdateIDs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/eks/services/mock_services/eks_mock.go
+++ b/pkg/eks/services/mock_services/eks_mock.go
@@ -155,6 +155,21 @@ func (mr *MockEKSServiceInterfaceMockRecorder) DescribeNodegroup(ctx, input inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNodegroup", reflect.TypeOf((*MockEKSServiceInterface)(nil).DescribeNodegroup), ctx, input)
 }
 
+// DescribeUpdates mocks base method.
+func (m *MockEKSServiceInterface) DescribeUpdates(ctx context.Context, input *eks.ListUpdatesInput, completedUpdates map[string]bool) ([]*eks.DescribeUpdateOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeUpdates", ctx, input, completedUpdates)
+	ret0, _ := ret[0].([]*eks.DescribeUpdateOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeUpdates indicates an expected call of DescribeUpdates.
+func (mr *MockEKSServiceInterfaceMockRecorder) DescribeUpdates(ctx, input, completedUpdates interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUpdates", reflect.TypeOf((*MockEKSServiceInterface)(nil).DescribeUpdates), ctx, input, completedUpdates)
+}
+
 // ListClusters mocks base method.
 func (m *MockEKSServiceInterface) ListClusters(ctx context.Context, input *eks.ListClustersInput) (*eks.ListClustersOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
the cluster refresh controller in rancher reverts some updates to the eks cluster because upstream eks cluster remains in active state for a few seconds after we push an update. 
Added a check to retrieve eks cluster updates and if in case any update is in progress the controller will just return now.
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/eks-operator/issues/752

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [X] squashed commits into logical changes
- [ ] includes documentation
- [X] adds unit tests
- [ ] adds or updates e2e tests
- [X] backport needed 
