### PR TITLE
[release-v2.10] generate cloud formation templates as per aws region

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -650,11 +650,16 @@ func (h *Handler) createOrGetServiceRole(ctx context.Context, config *eksv1.EKSC
 	if aws.ToString(config.Spec.ServiceRole) == "" {
 		logrus.Infof("Creating service role")
 
+		serviceRoleTemplate, err := templates.GetServiceRoleTemplate(config.Spec.Region)
+		if err != nil {
+			return "", err
+		}
+
 		stack, err := awsservices.CreateStack(ctx, &awsservices.CreateStackOptions{
 			CloudFormationService: awsSVCs.cloudformation,
 			StackName:             getServiceRoleName(config.Spec.DisplayName),
 			DisplayName:           config.Spec.DisplayName,
-			TemplateBody:          templates.ServiceRoleTemplate,
+			TemplateBody:          serviceRoleTemplate,
 			Capabilities:          []cftypes.Capability{cftypes.CapabilityCapabilityIam},
 			Parameters:            nil,
 		})

--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -652,7 +652,7 @@ func (h *Handler) createOrGetServiceRole(ctx context.Context, config *eksv1.EKSC
 
 		serviceRoleTemplate, err := templates.GetServiceRoleTemplate(config.Spec.Region)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("error getting service role template: %v", err)
 		}
 
 		stack, err := awsservices.CreateStack(ctx, &awsservices.CreateStackOptions{

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -1,14 +1,12 @@
 package eks
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha1"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"html/template"
 	"net/http"
 	"net/url"
 	"path"
@@ -298,7 +296,11 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 
 	if aws.ToString(opts.NodeGroup.NodeRole) == "" {
 		if opts.Config.Status.GeneratedNodeRole == "" {
-			finalTemplate := fmt.Sprintf(templates.NodeInstanceRoleTemplate, getEC2ServiceEndpoint(opts.Config.Spec.Region))
+			finalTemplate, err := templates.GetNodeInstanceRoleTemplate(opts.Config.Spec.Region)
+			if err != nil {
+				return "", "", err
+			}
+
 			output, err := CreateStack(ctx, &CreateStackOptions{
 				CloudFormationService: opts.CloudFormationService,
 				StackName:             fmt.Sprintf("%s-node-instance-role", opts.Config.Spec.DisplayName),
@@ -584,22 +586,10 @@ func getIssuerThumbprint(issuer string) (string, error) {
 }
 
 func createEBSCSIDriverRole(ctx context.Context, cfService services.CloudFormationServiceInterface, config *eksv1.EKSClusterConfig, oidcID string) (string, error) {
-	templateData := struct {
-		Region     string
-		ProviderID string
-	}{
-		Region:     config.Spec.Region,
-		ProviderID: oidcID,
-	}
-	tmpl, err := template.New("ebsrole").Parse(templates.EBSCSIDriverTemplate)
+	finalTemplate, err := templates.GetEBSCSIDriverTemplate(config.Spec.Region, oidcID)
 	if err != nil {
 		return "", err
 	}
-	buf := &bytes.Buffer{}
-	if execErr := tmpl.Execute(buf, templateData); execErr != nil {
-		return "", err
-	}
-	finalTemplate := buf.String()
 
 	output, err := CreateStack(ctx, &CreateStackOptions{
 		CloudFormationService: cfService,

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -298,7 +298,7 @@ func CreateNodeGroup(ctx context.Context, opts *CreateNodeGroupOptions) (string,
 		if opts.Config.Status.GeneratedNodeRole == "" {
 			finalTemplate, err := templates.GetNodeInstanceRoleTemplate(opts.Config.Spec.Region)
 			if err != nil {
-				return "", "", err
+				return "", "", fmt.Errorf("error getting node instance role template: %v", err)
 			}
 
 			output, err := CreateStack(ctx, &CreateStackOptions{
@@ -588,7 +588,7 @@ func getIssuerThumbprint(issuer string) (string, error) {
 func createEBSCSIDriverRole(ctx context.Context, cfService services.CloudFormationServiceInterface, config *eksv1.EKSClusterConfig, oidcID string) (string, error) {
 	finalTemplate, err := templates.GetEBSCSIDriverTemplate(config.Spec.Region, oidcID)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("error getting ebs csi driver template: %v", err)
 	}
 
 	output, err := CreateStack(ctx, &CreateStackOptions{

--- a/templates/helpers.go
+++ b/templates/helpers.go
@@ -1,0 +1,104 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+)
+
+type EBSCSIDriverTemplateData struct {
+	AWSArnPrefix string
+	Region       string
+	ProviderID   string
+	AWSDomain    string
+}
+
+type NodeInstanceRoleTemplateData struct {
+	AWSArnPrefix string
+	EC2Service   string
+}
+
+func getAWSDNSSuffix(region string) string {
+	if p, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok {
+		return p.DNSSuffix()
+	}
+	return endpoints.AwsPartition().DNSSuffix()
+}
+
+func getEC2ServiceEndpoint(region string) string {
+	return "ec2." + getAWSDNSSuffix(region)
+}
+
+func getArnPrefixForRegion(region string) string {
+	if p, ok := endpoints.PartitionForRegion(endpoints.DefaultPartitions(), region); ok {
+		return "arn:" + p.ID()
+	}
+	return "arn:" + endpoints.AwsPartition().ID()
+}
+
+func GetServiceRoleTemplate(region string) (string, error) {
+	tmpl, err := template.New("serviceRole").Parse(ServiceRoleTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	// Create the data for the template
+	data := struct {
+		AWSArnPrefix string
+	}{
+		AWSArnPrefix: getArnPrefixForRegion(region),
+	}
+
+	// Execute the template
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetNodeInstanceRoleTemplate(region string) (string, error) {
+	tmpl, err := template.New("nodeInstanceRole").Parse(NodeInstanceRoleTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	// Create the data for the template
+	data := NodeInstanceRoleTemplateData{
+		AWSArnPrefix: getArnPrefixForRegion(region),
+		EC2Service:   getEC2ServiceEndpoint(region),
+	}
+
+	// Execute the template
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetEBSCSIDriverTemplate(region string, providerID string) (string, error) {
+	tmpl, err := template.New("ebsrole").Parse(EBSCSIDriverTemplate)
+	if err != nil {
+		return "", err
+	}
+
+	// Create the data for the template
+	data := EBSCSIDriverTemplateData{
+		AWSArnPrefix: getArnPrefixForRegion(region),
+		AWSDomain:    getAWSDNSSuffix(region),
+		Region:       region,
+		ProviderID:   providerID,
+	}
+
+	// Execute the template
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}

--- a/templates/suite_test.go
+++ b/templates/suite_test.go
@@ -1,0 +1,13 @@
+package templates
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTemplates(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Templates Suite")
+}

--- a/templates/template.go
+++ b/templates/template.go
@@ -211,13 +211,13 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: %s
+              Service: {{.EC2Service}}
             Action: sts:AssumeRole
       Path: "/"
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
-        - arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
-        - arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+        - {{.AWSArnPrefix}}:iam::aws:policy/AmazonEKSWorkerNodePolicy
+        - {{.AWSArnPrefix}}:iam::aws:policy/AmazonEKS_CNI_Policy
+        - {{.AWSArnPrefix}}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
 
 Outputs:
 
@@ -245,8 +245,8 @@ Resources:
           Action:
           - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonEKSServicePolicy
-        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - {{.AWSArnPrefix}}:iam::aws:policy/AmazonEKSServicePolicy
+        - {{.AWSArnPrefix}}:iam::aws:policy/AmazonEKSClusterPolicy
 
 Outputs:
 
@@ -266,7 +266,7 @@ Parameters:
 
   AmazonEBSCSIDriverPolicyArn:
     Type: String
-    Default: arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+    Default: {{.AWSArnPrefix}}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
     Description: The ARN of the managed policy
 
 Resources:
@@ -280,12 +280,12 @@ Resources:
         - Effect: Allow
           Principal:
             Federated:
-            - !Sub "arn:aws:iam::${AWS::AccountId}:oidc-provider/oidc.eks.{{.Region}}.amazonaws.com/id/{{.ProviderID}}"
+            - !Sub "{{.AWSArnPrefix}}:iam::${AWS::AccountId}:oidc-provider/oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}"
           Action: sts:AssumeRoleWithWebIdentity
           Condition:
             StringEquals: {
-              "oidc.eks.{{.Region}}.amazonaws.com/id/{{.ProviderID}}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
-              "oidc.eks.{{.Region}}.amazonaws.com/id/{{.ProviderID}}:aud": "sts.amazonaws.com"
+              "oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+              "oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}:aud": "sts.{{.AWSDomain}}"
             }
       Path: "/"
       ManagedPolicyArns:

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -1,0 +1,124 @@
+package templates
+
+import (
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Templates", func() {
+	Context("Helper functions", func() {
+		Describe("getAWSDNSSuffix", func() {
+			It("should return the correct DNS suffix for a given region", func() {
+				Expect(getAWSDNSSuffix("us-east-1")).To(Equal("amazonaws.com"))
+				Expect(getAWSDNSSuffix("cn-north-1")).To(Equal("amazonaws.com.cn"))
+				Expect(getAWSDNSSuffix("us-gov-west-1")).To(Equal("amazonaws.com"))
+			})
+
+			It("should return default DNS suffix for unknown region", func() {
+				Expect(getAWSDNSSuffix("unknown-region")).To(Equal(endpoints.AwsPartition().DNSSuffix()))
+			})
+		})
+
+		Describe("getEC2ServiceEndpoint", func() {
+			It("should return the correct EC2 service endpoint for a given region", func() {
+				Expect(getEC2ServiceEndpoint("us-east-1")).To(Equal("ec2.amazonaws.com"))
+				Expect(getEC2ServiceEndpoint("us-gov-west-1")).To(Equal("ec2.amazonaws.com"))
+				Expect(getEC2ServiceEndpoint("cn-north-1")).To(Equal("ec2.amazonaws.com.cn"))
+			})
+		})
+
+		Describe("getArnPrefixForRegion", func() {
+			It("should return the correct ARN prefix for a given region", func() {
+				Expect(getArnPrefixForRegion("us-east-1")).To(Equal("arn:aws"))
+				Expect(getArnPrefixForRegion("cn-north-1")).To(Equal("arn:aws-cn"))
+				Expect(getArnPrefixForRegion("us-gov-west-1")).To(Equal("arn:aws-us-gov"))
+			})
+
+			It("should return default ARN prefix for unknown region", func() {
+				Expect(getArnPrefixForRegion("unknown-region")).To(Equal("arn:" + endpoints.AwsPartition().ID()))
+			})
+		})
+	})
+
+	Context("Template generation", func() {
+		Describe("GetServiceRoleTemplate", func() {
+			It("should generate a valid service role template for us-east-1", func() {
+				tmpl, err := GetServiceRoleTemplate("us-east-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("AWSServiceRoleForAmazonEKS"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKSServicePolicy"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"))
+			})
+
+			It("should generate a valid service role template for cn-north-1", func() {
+				tmpl, err := GetServiceRoleTemplate("cn-north-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("arn:aws-cn:iam::aws:policy/AmazonEKSServicePolicy"))
+			})
+
+			It("should generate a valid service role template for us-gov-west-1", func() {
+				tmpl, err := GetServiceRoleTemplate("us-gov-west-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("arn:aws-us-gov:iam::aws:policy/AmazonEKSServicePolicy"))
+			})
+		})
+
+		Describe("GetNodeInstanceRoleTemplate", func() {
+			It("should generate a valid node instance role template for us-east-1", func() {
+				tmpl, err := GetNodeInstanceRoleTemplate("us-east-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("NodeInstanceRole"))
+				Expect(tmpl).To(ContainSubstring("ec2.amazonaws.com"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"))
+			})
+
+			It("should generate a valid node instance role template for cn-north-1", func() {
+				tmpl, err := GetNodeInstanceRoleTemplate("cn-north-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("ec2.amazonaws.com.cn"))
+				Expect(tmpl).To(ContainSubstring("arn:aws-cn:iam::aws:policy/AmazonEKSWorkerNodePolicy"))
+			})
+
+			It("should generate a valid node instance role template for us-gov-west-1", func() {
+				tmpl, err := GetNodeInstanceRoleTemplate("us-gov-west-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("ec2.amazonaws.com"))
+				Expect(tmpl).To(ContainSubstring("arn:aws-us-gov:iam::aws:policy/AmazonEKSWorkerNodePolicy"))
+			})
+		})
+
+		Describe("GetEBSCSIDriverTemplate", func() {
+			It("should generate a valid EBS CSI driver template for us-east-1", func() {
+				providerID := "ABCDEF12345678"
+				tmpl, err := GetEBSCSIDriverTemplate("us-east-1", providerID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("AWSEBSCSIDriverRoleForAmazonEKS"))
+				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
+				Expect(tmpl).To(ContainSubstring("oidc.eks.us-east-1.amazonaws.com/id/" + providerID))
+				Expect(tmpl).To(ContainSubstring("system:serviceaccount:kube-system:ebs-csi-controller-sa"))
+				Expect(tmpl).To(ContainSubstring("sts.amazonaws.com"))
+			})
+
+			It("should generate a valid EBS CSI driver template for cn-north-1", func() {
+				providerID := "ABCDEF12345678"
+				tmpl, err := GetEBSCSIDriverTemplate("cn-north-1", providerID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("arn:aws-cn:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
+				Expect(tmpl).To(ContainSubstring("oidc.eks.cn-north-1.amazonaws.com.cn/id/" + providerID))
+				Expect(tmpl).To(ContainSubstring("sts.amazonaws.com.cn"))
+			})
+
+			It("should generate a valid EBS CSI driver template for us-gov-west-1", func() {
+				providerID := "ABCDEF12345678"
+				tmpl, err := GetEBSCSIDriverTemplate("us-gov-west-1", providerID)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tmpl).To(ContainSubstring("arn:aws-us-gov:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
+				Expect(tmpl).To(ContainSubstring("oidc.eks.us-gov-west-1.amazonaws.com/id/" + providerID))
+				Expect(tmpl).To(ContainSubstring("sts.amazonaws.com"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:
backport PR for: https://github.com/rancher/eks-operator/pull/1271
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue # https://github.com/rancher/rancher/issues/49734

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
