### PR TITLE
[v2.13] Bump go toolchain version to v1.24.9 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rancher/eks-operator
 
-go 1.24.9
+go 1.24.0
+
+toolchain go1.24.9
 
 replace k8s.io/client-go => k8s.io/client-go v0.34.1
 


### PR DESCRIPTION
- Revert the go version to `v1.24.0` and only bump toolchain version to `v1.24.9`