### PR TITLE
[v2.13] Allow support for duakStackEndpoints

### DIFF
--- a/controller/internal.go
+++ b/controller/internal.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newAWSConfigV2(ctx context.Context, secretClient wranglerv1.SecretClient, spec eksv1.EKSClusterConfigSpec) (aws.Config, error) {
-	cfg, err := config.LoadDefaultConfig(ctx)
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithUseDualStackEndpoint(aws.DualStackEndpointStateEnabled))
 	if err != nil {
 		return cfg, fmt.Errorf("error loading default AWS config: %w", err)
 	}


### PR DESCRIPTION
- https://github.com/rancher/rancher/issues/52154
https://github.com/rancher/rancher/issues/53584
### Summary

- enabled dualstackendpoint option during configuration generation to provide dual-stack support for clusters that require both IPv4 and IPv6 connectivity.