### PR TITLE
fix(eks): correct OIDC provider URL for IPv6 EBS CSI driver role trust policy

### DIFF
--- a/controller/eks-cluster-config-handler.go
+++ b/controller/eks-cluster-config-handler.go
@@ -747,7 +747,7 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, upstreamSpec *
 
 	if templates.IsIPv6(config.Spec.IPFamily) {
 		logrus.Infof("Ensuring OIDC Provider exists for IPv6 cluster [%s]", config.Spec.DisplayName)
-		_, err := awsservices.ConfigureOIDCProvider(ctx, awsSVCs.iam, awsSVCs.eks, config)
+		_, _, err := awsservices.ConfigureOIDCProvider(ctx, awsSVCs.iam, awsSVCs.eks, config)
 		if err != nil {
 			return config, fmt.Errorf("error configuring OIDC provider for IPv6: %w", err)
 		}

--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -507,51 +507,59 @@ type EnableEBSCSIDriverInput struct {
 // EnableEBSCSIDriver manages the installation of the EBS CSI driver for EKS, including the
 // creation of the OIDC Provider, the IAM role and the validation and installation of the EKS add-on
 func EnableEBSCSIDriver(ctx context.Context, opts *EnableEBSCSIDriverInput) error {
-	oidcID, err := ConfigureOIDCProvider(ctx, opts.IAMService, opts.EKSService, opts.Config)
+	oidcID, oidcHost, err := ConfigureOIDCProvider(ctx, opts.IAMService, opts.EKSService, opts.Config)
 	if err != nil {
 		return fmt.Errorf("could not configure oidc provider: %w", err)
 	}
-	roleArn, err := createEBSCSIDriverRole(ctx, opts.CFService, opts.Config, oidcID)
+	roleArn, err := createEBSCSIDriverRole(ctx, opts.CFService, opts.Config, oidcID, oidcHost)
 	if err != nil {
 		return fmt.Errorf("could not create ebs csi driver role: %w", err)
 	}
 	if _, err := installEBSAddon(ctx, opts.EKSService, opts.Config, roleArn, opts.AddonVersion); err != nil {
 		return fmt.Errorf("failed to install ebs csi driver addon: %w", err)
 	}
-
 	return nil
 }
 
-func ConfigureOIDCProvider(ctx context.Context, iamService services.IAMServiceInterface, eksService services.EKSServiceInterface, config *eksv1.EKSClusterConfig) (string, error) {
+func ConfigureOIDCProvider(ctx context.Context, iamService services.IAMServiceInterface, eksService services.EKSServiceInterface, config *eksv1.EKSClusterConfig) (string, string, error) {
 	output, err := iamService.ListOIDCProviders(ctx, &iam.ListOpenIDConnectProvidersInput{})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	clusterOutput, err := eksService.DescribeCluster(ctx, &eks.DescribeClusterInput{
 		Name: aws.String(config.Spec.DisplayName),
 	})
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	if clusterOutput == nil {
-		return "", fmt.Errorf("could not find cluster [%s (id: %s)]", config.Spec.DisplayName, config.Name)
+		return "", "", fmt.Errorf("could not find cluster [%s (id: %s)]", config.Spec.DisplayName, config.Name)
 	}
 	id := path.Base(*clusterOutput.Cluster.Identity.Oidc.Issuer)
 
+	oidcIssuer := clusterOutput.Cluster.Identity.Oidc.Issuer
+
+	parsedIssuer, err := url.Parse(*oidcIssuer)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing oidc issuer: %w", err)
+	}
+
+	oidcHost := parsedIssuer.Host
+
 	for _, prov := range output.OpenIDConnectProviderList {
 		if strings.Contains(*prov.Arn, id) {
-			return "", nil
+			return id, oidcHost, nil
 		}
 	}
 
-	oidcIssuer := clusterOutput.Cluster.Identity.Oidc.Issuer
+	thumbprintIssuer := oidcIssuer
 	if templates.IsIPv6(config.Spec.IPFamily) {
-		oidcIssuer = transformOIDC(oidcIssuer)
+		thumbprintIssuer = transformOIDC(oidcIssuer)
 	}
 
-	thumbprint, err := getIssuerThumbprint(*oidcIssuer)
+	thumbprint, err := getIssuerThumbprint(*thumbprintIssuer)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	input := &iam.CreateOpenIDConnectProviderInput{
 		ClientIDList:   []string{string(defaultAudienceOpenIDConnect)},
@@ -561,10 +569,10 @@ func ConfigureOIDCProvider(ctx context.Context, iamService services.IAMServiceIn
 	}
 	newOIDC, err := iamService.CreateOIDCProvider(ctx, input)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	return path.Base(*newOIDC.OpenIDConnectProviderArn), nil
+	return path.Base(*newOIDC.OpenIDConnectProviderArn), oidcHost, nil
 }
 
 func getIssuerThumbprint(issuer string) (string, error) {
@@ -600,8 +608,8 @@ func getIssuerThumbprint(issuer string) (string, error) {
 	return fmt.Sprintf("%x", sha1.Sum(root.Raw)), nil
 }
 
-func createEBSCSIDriverRole(ctx context.Context, cfService services.CloudFormationServiceInterface, config *eksv1.EKSClusterConfig, oidcID string) (string, error) {
-	finalTemplate, err := templates.GetEBSCSIDriverTemplate(config.Spec.Region, oidcID)
+func createEBSCSIDriverRole(ctx context.Context, cfService services.CloudFormationServiceInterface, config *eksv1.EKSClusterConfig, oidcID, oidcHost string) (string, error) {
+	finalTemplate, err := templates.GetEBSCSIDriverTemplate(config.Spec.Region, oidcID, oidcHost)
 	if err != nil {
 		return "", fmt.Errorf("error getting ebs csi driver template: %v", err)
 	}
@@ -643,7 +651,6 @@ func installEBSAddon(ctx context.Context, eksService services.EKSServiceInterfac
 	return *addonOutput.Addon.AddonArn, nil
 }
 
-// TransformOIDC converts a standard EKS OIDC URL to a dual-stack URL.
 func transformOIDC(issuerURL *string) *string {
 	if issuerURL == nil {
 		return nil

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -1247,7 +1247,7 @@ var _ = Describe("installEBSCSIDriver", func() {
 		iamServiceMock.EXPECT().ListOIDCProviders(ctx, gomock.Any()).Return(oidcListProvidersOutput, nil)
 		eksServiceMock.EXPECT().DescribeCluster(ctx, gomock.Any()).Return(eksClusterOutput, nil)
 		iamServiceMock.EXPECT().CreateOIDCProvider(ctx, gomock.Any()).Return(oidcCreateProviderOutput, nil)
-		_, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		_, _, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).To(Succeed())
 	})
 
@@ -1257,13 +1257,13 @@ var _ = Describe("installEBSCSIDriver", func() {
 		}
 		eksServiceMock.EXPECT().DescribeCluster(ctx, gomock.Any()).Return(eksClusterOutput, nil)
 		iamServiceMock.EXPECT().ListOIDCProviders(ctx, gomock.Any()).Return(oidcListProvidersOutput, nil)
-		_, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		_, _, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).To(Succeed())
 	})
 
 	It("should fail to list oidc providers", func() {
 		iamServiceMock.EXPECT().ListOIDCProviders(ctx, gomock.Any()).Return(nil, fmt.Errorf("failed to list oidc providers"))
-		_, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		_, _, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).ToNot(Succeed())
 	})
 
@@ -1274,7 +1274,7 @@ var _ = Describe("installEBSCSIDriver", func() {
 		iamServiceMock.EXPECT().ListOIDCProviders(ctx, gomock.Any()).Return(oidcListProvidersOutput, nil)
 		eksServiceMock.EXPECT().DescribeCluster(ctx, gomock.Any()).Return(eksClusterOutput, nil)
 		iamServiceMock.EXPECT().CreateOIDCProvider(ctx, gomock.Any()).Return(nil, fmt.Errorf("failed to create oidc provider"))
-		_, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
+		_, _, err := ConfigureOIDCProvider(ctx, enableEBSCSIDriverInput.IAMService, enableEBSCSIDriverInput.EKSService, enableEBSCSIDriverInput.Config)
 		Expect(err).ToNot(Succeed())
 	})
 
@@ -1294,14 +1294,14 @@ var _ = Describe("installEBSCSIDriver", func() {
 					},
 				},
 			}, nil)
-		_, err := createEBSCSIDriverRole(ctx, enableEBSCSIDriverInput.CFService, enableEBSCSIDriverInput.Config, "")
+		_, err := createEBSCSIDriverRole(ctx, enableEBSCSIDriverInput.CFService, enableEBSCSIDriverInput.Config, "", "oidc.eks.region.amazonaws.com")
 		Expect(err).To(Succeed())
 	})
 
 	It("should fail to create driver iam role", func() {
 		cloudFormationServiceMock.EXPECT().CreateStack(ctx, gomock.Any()).Return(nil, nil)
 		cloudFormationServiceMock.EXPECT().DescribeStacks(ctx, gomock.Any()).Return(nil, fmt.Errorf("failed to describe stack"))
-		_, err := createEBSCSIDriverRole(ctx, enableEBSCSIDriverInput.CFService, enableEBSCSIDriverInput.Config, "")
+		_, err := createEBSCSIDriverRole(ctx, enableEBSCSIDriverInput.CFService, enableEBSCSIDriverInput.Config, "", "oidc.eks.region.amazonaws.com")
 		Expect(err).ToNot(Succeed())
 	})
 

--- a/pkg/eks/get.go
+++ b/pkg/eks/get.go
@@ -109,5 +109,10 @@ func CheckEBSAddon(ctx context.Context, clusterName string, eksService services.
 		return "", nil
 	}
 
+	if output.Addon.Status == ekstypes.AddonStatusCreateFailed ||
+		output.Addon.Status == ekstypes.AddonStatusDegraded {
+		return "", nil
+	}
+
 	return *output.Addon.AddonArn, nil
 }

--- a/templates/helpers.go
+++ b/templates/helpers.go
@@ -15,6 +15,7 @@ type EBSCSIDriverTemplateData struct {
 	Region       string
 	ProviderID   string
 	AWSDomain    string
+	OIDCHost     string
 }
 
 type NodeInstanceRoleTemplateData struct {
@@ -88,7 +89,7 @@ func GetNodeInstanceRoleTemplate(region string, ipFamily *string) (string, error
 	return buf.String(), nil
 }
 
-func GetEBSCSIDriverTemplate(region string, providerID string) (string, error) {
+func GetEBSCSIDriverTemplate(region string, providerID, oidcHost string) (string, error) {
 	tmpl, err := template.New("ebsrole").Parse(EBSCSIDriverTemplate)
 	if err != nil {
 		return "", err
@@ -100,6 +101,7 @@ func GetEBSCSIDriverTemplate(region string, providerID string) (string, error) {
 		AWSDomain:    getAWSDNSSuffix(region),
 		Region:       region,
 		ProviderID:   providerID,
+		OIDCHost:     oidcHost,
 	}
 
 	// Execute the template

--- a/templates/template.go
+++ b/templates/template.go
@@ -559,12 +559,12 @@ Resources:
         - Effect: Allow
           Principal:
             Federated:
-            - !Sub "{{.AWSArnPrefix}}:iam::${AWS::AccountId}:oidc-provider/oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}"
+            - !Sub "{{.AWSArnPrefix}}:iam::${AWS::AccountId}:oidc-provider/{{.OIDCHost}}/id/{{.ProviderID}}"
           Action: sts:AssumeRoleWithWebIdentity
           Condition:
             StringEquals: {
-              "oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
-              "oidc.eks.{{.Region}}.{{.AWSDomain}}/id/{{.ProviderID}}:aud": "sts.{{.AWSDomain}}"
+              "{{.OIDCHost}}/id/{{.ProviderID}}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa",
+              "{{.OIDCHost}}/id/{{.ProviderID}}:aud": "sts.{{.AWSDomain}}"
             }
       Path: "/"
       ManagedPolicyArns:

--- a/templates/templates_test.go
+++ b/templates/templates_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Templates", func() {
 		Describe("GetEBSCSIDriverTemplate", func() {
 			It("should generate a valid EBS CSI driver template for us-east-1", func() {
 				providerID := "ABCDEF12345678"
-				tmpl, err := GetEBSCSIDriverTemplate("us-east-1", providerID)
+				tmpl, err := GetEBSCSIDriverTemplate("us-east-1", providerID, "oidc.eks.us-east-1.amazonaws.com")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tmpl).To(ContainSubstring("AWSEBSCSIDriverRoleForAmazonEKS"))
 				Expect(tmpl).To(ContainSubstring("arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
@@ -105,7 +105,7 @@ var _ = Describe("Templates", func() {
 
 			It("should generate a valid EBS CSI driver template for cn-north-1", func() {
 				providerID := "ABCDEF12345678"
-				tmpl, err := GetEBSCSIDriverTemplate("cn-north-1", providerID)
+				tmpl, err := GetEBSCSIDriverTemplate("cn-north-1", providerID, "oidc.eks.cn-north-1.amazonaws.com.cn")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tmpl).To(ContainSubstring("arn:aws-cn:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
 				Expect(tmpl).To(ContainSubstring("oidc.eks.cn-north-1.amazonaws.com.cn/id/" + providerID))
@@ -114,7 +114,7 @@ var _ = Describe("Templates", func() {
 
 			It("should generate a valid EBS CSI driver template for us-gov-west-1", func() {
 				providerID := "ABCDEF12345678"
-				tmpl, err := GetEBSCSIDriverTemplate("us-gov-west-1", providerID)
+				tmpl, err := GetEBSCSIDriverTemplate("us-gov-west-1", providerID, "oidc.eks.us-gov-west-1.amazonaws.com")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(tmpl).To(ContainSubstring("arn:aws-us-gov:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"))
 				Expect(tmpl).To(ContainSubstring("oidc.eks.us-gov-west-1.amazonaws.com/id/" + providerID))


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:
kind/bug
-->

**What this PR does / why we need it**:

For IPv6 EKS clusters with the EBS CSI Driver enabled, the CSI controller pods
were stuck in CrashLoopBackOff with `InvalidIdentityToken` errors.

Root cause: `transformOIDC()` was being applied to the OIDC provider registration
URL, causing a mismatch between:
- The OIDC provider registered in IAM: `oidc-eks.<region>.api.aws`
- The token issuer EKS embeds in service account tokens: `oidc.eks.<region>.amazonaws.com`

AWS STS compares the token issuer against registered OIDC providers and trust
policies — since they didn't match, `AssumeRoleWithWebIdentity` always failed
with `InvalidIdentityToken`.

The fix separates the two concerns:
- `transformOIDC()` is now used **only** for fetching the TLS thumbprint, where
  the IPv6 dual-stack endpoint is needed to get the correct certificate.
- OIDC provider registration and IAM trust policy both use the **original issuer
  URL** from `DescribeCluster`, which matches what EKS embeds in tokens.

**Which issue(s) this PR fixes**

Issue https://github.com/rancher/rancher/issues/54029

**Special notes for your reviewer**:

The key insight is that EKS always issues service account tokens with the
original `oidc.eks.<region>.amazonaws.com` issuer URL regardless of IP family.
The dual-stack `oidc-eks.<region>.api.aws` endpoint exists only for network
connectivity purposes on IPv6 clusters — it should never be used for IAM
provider registration or trust policies.

Before this fix:
```
IAM OIDC Provider:  oidc-eks.<region>.api.aws        ❌
IAM Trust Policy:   oidc-eks.<region>.api.aws        ❌
Token Issuer:       oidc.eks.<region>.amazonaws.com
→ MISMATCH → InvalidIdentityToken
```

After this fix:
```
IAM OIDC Provider:  oidc.eks.<region>.amazonaws.com  ✅
IAM Trust Policy:   oidc.eks.<region>.amazonaws.com  ✅
Token Issuer:       oidc.eks.<region>.amazonaws.com
→ MATCH → EBS CSI Driver Running
```

IPv4 clusters are unaffected since `transformOIDC` was never called for them.

**Checklist**:
- [ ] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed