### PR TITLE
[release/v2.14] Added default public CIDR for IPv6 case

### DIFF
--- a/pkg/eks/create.go
+++ b/pkg/eks/create.go
@@ -69,7 +69,7 @@ func newClusterInput(config *eksv1.EKSClusterConfig, roleARN string) *eks.Create
 			EndpointPublicAccess:  config.Spec.PublicAccess,
 			SecurityGroupIds:      config.Status.SecurityGroups,
 			SubnetIds:             config.Status.Subnets,
-			PublicAccessCidrs:     getPublicAccessCidrs(config.Spec.PublicAccessSources),
+			PublicAccessCidrs:     getPublicAccessCidrs(config.Spec.PublicAccessSources, config.Spec.IPFamily),
 		},
 		Tags:    getTags(config.Spec.Tags),
 		Logging: getLogging(config.Spec.LoggingTypes),
@@ -454,9 +454,12 @@ func getLogging(loggingTypes []string) *ekstypes.Logging {
 	}
 }
 
-func getPublicAccessCidrs(publicAccessCidrs []string) []string {
+func getPublicAccessCidrs(publicAccessCidrs []string, ipFamily *string) []string {
 	if len(publicAccessCidrs) == 0 {
-		return []string{"0.0.0.0/0"}
+		if templates.IsIPv6(ipFamily) {
+			return []string{allOpenIPv4, allOpenIPv6}
+		}
+		return []string{allOpenIPv4}
 	}
 
 	return publicAccessCidrs

--- a/pkg/eks/create_test.go
+++ b/pkg/eks/create_test.go
@@ -110,6 +110,14 @@ var _ = Describe("newClusterInput", func() {
 		Expect(clusterInput.ResourcesVpcConfig.PublicAccessCidrs).ToNot(BeNil())
 		Expect(clusterInput.ResourcesVpcConfig.PublicAccessCidrs).To(Equal([]string{"0.0.0.0/0"}))
 	})
+	It("should successfully create a cluster input with no public access cidrs set for IPv6", func() {
+		config.Spec.PublicAccessSources = []string{}
+		config.Spec.IPFamily = aws.String("ipv6")
+		clusterInput := newClusterInput(config, roleARN)
+		Expect(clusterInput).ToNot(BeNil())
+		Expect(clusterInput.ResourcesVpcConfig.PublicAccessCidrs).ToNot(BeNil())
+		Expect(clusterInput.ResourcesVpcConfig.PublicAccessCidrs).To(Equal([]string{"0.0.0.0/0", "::/0"}))
+	})
 
 	It("should successfully create a cluster with no tags set", func() {
 		config.Spec.Tags = map[string]string{}

--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -11,6 +11,7 @@ import (
 
 	eksv1 "github.com/rancher/eks-operator/pkg/apis/eks.cattle.io/v1"
 	"github.com/rancher/eks-operator/pkg/eks/services"
+	"github.com/rancher/eks-operator/templates"
 	"github.com/rancher/eks-operator/utils"
 )
 
@@ -159,8 +160,8 @@ func UpdateClusterPublicAccessSources(ctx context.Context, opts *UpdateClusterPu
 	updated := false
 	// check public access CIDRs for update (public access sources)
 
-	filteredSpecPublicAccessSources := filterPublicAccessSources(opts.Config.Spec.PublicAccessSources)
-	filteredUpstreamPublicAccessSources := filterPublicAccessSources(opts.UpstreamClusterSpec.PublicAccessSources)
+	filteredSpecPublicAccessSources := filterPublicAccessSources(opts.Config.Spec.PublicAccessSources, opts.Config.Spec.IPFamily)
+	filteredUpstreamPublicAccessSources := filterPublicAccessSources(opts.UpstreamClusterSpec.PublicAccessSources, opts.UpstreamClusterSpec.IPFamily)
 	if !utils.CompareStringSliceElements(filteredSpecPublicAccessSources, filteredUpstreamPublicAccessSources) {
 		logrus.Infof("Updating public access source config to %v  for cluster [%s (id: %s)]", opts.Config.Spec.PublicAccessSources, opts.Config.Spec.DisplayName, opts.Config.Name)
 		logrus.Debugf("config: %v, upstream: %v", opts.Config.Spec.PublicAccessSources, opts.UpstreamClusterSpec.PublicAccessSources)
@@ -275,19 +276,25 @@ func getLoggingTypesToEnable(loggingTypes []string, upstreamLoggingTypes []strin
 	return ekstypes.LogSetup{}
 }
 
-func filterPublicAccessSources(sources []string) []string {
+func filterPublicAccessSources(sources []string, ipFamily *string) []string {
 	if len(sources) == 0 {
-		return nil
+		return []string{}
 	}
-	if len(sources) == 1 && (sources[0] == allOpenIPv4 || sources[0] == allOpenIPv6) {
-		return nil
-	}
-	if len(sources) == 2 {
-		hasIPv4 := sources[0] == allOpenIPv4 || sources[1] == allOpenIPv4
-		hasIPv6 := sources[0] == allOpenIPv6 || sources[1] == allOpenIPv6
 
-		if hasIPv4 && hasIPv6 {
-			return nil
+	isIPv6 := templates.IsIPv6(ipFamily)
+
+	if isIPv6 {
+		if len(sources) == 2 {
+			hasIPv4 := sources[0] == allOpenIPv4 || sources[1] == allOpenIPv4
+			hasIPv6 := sources[0] == allOpenIPv6 || sources[1] == allOpenIPv6
+
+			if hasIPv4 && hasIPv6 {
+				return []string{}
+			}
+		}
+	} else {
+		if len(sources) == 1 && sources[0] == allOpenIPv4 {
+			return []string{}
 		}
 	}
 

--- a/pkg/eks/update.go
+++ b/pkg/eks/update.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	allOpen = "0.0.0.0/0"
+	allOpenIPv4 = "0.0.0.0/0"
+	allOpenIPv6 = "::/0"
 )
 
 type UpdateClusterVersionOpts struct {
@@ -167,7 +168,7 @@ func UpdateClusterPublicAccessSources(ctx context.Context, opts *UpdateClusterPu
 			&eks.UpdateClusterConfigInput{
 				Name: aws.String(opts.Config.Spec.DisplayName),
 				ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
-					PublicAccessCidrs: getPublicAccessCidrs(opts.Config.Spec.PublicAccessSources),
+					PublicAccessCidrs: getPublicAccessCidrs(opts.Config.Spec.PublicAccessSources, opts.Config.Spec.IPFamily),
 				},
 			},
 		)
@@ -278,8 +279,17 @@ func filterPublicAccessSources(sources []string) []string {
 	if len(sources) == 0 {
 		return nil
 	}
-	if len(sources) == 1 && sources[0] == allOpen {
+	if len(sources) == 1 && (sources[0] == allOpenIPv4 || sources[0] == allOpenIPv6) {
 		return nil
 	}
+	if len(sources) == 2 {
+		hasIPv4 := sources[0] == allOpenIPv4 || sources[1] == allOpenIPv4
+		hasIPv6 := sources[0] == allOpenIPv6 || sources[1] == allOpenIPv6
+
+		if hasIPv4 && hasIPv6 {
+			return nil
+		}
+	}
+
 	return sources
 }

--- a/pkg/eks/update_test.go
+++ b/pkg/eks/update_test.go
@@ -430,6 +430,7 @@ var _ = Describe("UpdateClusterPublicAccessSources", func() {
 		updateClusterPublicAccessSourcesOpts.Config.Spec.PublicAccessSources = []string{}
 		updateClusterPublicAccessSourcesOpts.Config.Spec.IPFamily = aws.String("ipv6")
 		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.PublicAccessSources = []string{"0.0.0.0/0", "::/0"}
+		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.IPFamily = aws.String("ipv6")
 		updated, err := UpdateClusterPublicAccessSources(ctx, updateClusterPublicAccessSourcesOpts)
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
@@ -439,6 +440,7 @@ var _ = Describe("UpdateClusterPublicAccessSources", func() {
 		updateClusterPublicAccessSourcesOpts.Config.Spec.PublicAccessSources = []string{}
 		updateClusterPublicAccessSourcesOpts.Config.Spec.IPFamily = aws.String("ipv6")
 		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.PublicAccessSources = []string{"0.0.0.0/0"}
+		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.IPFamily = aws.String("ipv6")
 
 		eksServiceMock.EXPECT().UpdateClusterConfig(ctx,
 			&eks.UpdateClusterConfigInput{

--- a/pkg/eks/update_test.go
+++ b/pkg/eks/update_test.go
@@ -426,6 +426,33 @@ var _ = Describe("UpdateClusterPublicAccessSources", func() {
 		Expect(updated).To(BeFalse())
 		Expect(err).NotTo(HaveOccurred())
 	})
+	It("should not update cluster public access sources if using default IPv6 dual-stack CIDRs", func() {
+		updateClusterPublicAccessSourcesOpts.Config.Spec.PublicAccessSources = []string{}
+		updateClusterPublicAccessSourcesOpts.Config.Spec.IPFamily = aws.String("ipv6")
+		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.PublicAccessSources = []string{"0.0.0.0/0", "::/0"}
+		updated, err := UpdateClusterPublicAccessSources(ctx, updateClusterPublicAccessSourcesOpts)
+		Expect(updated).To(BeFalse())
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should update cluster public access sources to include IPv6 default if missing upstream", func() {
+		updateClusterPublicAccessSourcesOpts.Config.Spec.PublicAccessSources = []string{}
+		updateClusterPublicAccessSourcesOpts.Config.Spec.IPFamily = aws.String("ipv6")
+		updateClusterPublicAccessSourcesOpts.UpstreamClusterSpec.PublicAccessSources = []string{"0.0.0.0/0"}
+
+		eksServiceMock.EXPECT().UpdateClusterConfig(ctx,
+			&eks.UpdateClusterConfigInput{
+				Name: aws.String(updateClusterPublicAccessSourcesOpts.Config.Spec.DisplayName),
+				ResourcesVpcConfig: &ekstypes.VpcConfigRequest{
+					PublicAccessCidrs: []string{"0.0.0.0/0", "::/0"},
+				},
+			},
+		).Return(nil, nil)
+
+		updated, err := UpdateClusterPublicAccessSources(ctx, updateClusterPublicAccessSourcesOpts)
+		Expect(updated).To(BeTrue())
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	It("should return error if update cluster public access sources failed", func() {
 		eksServiceMock.EXPECT().UpdateClusterConfig(ctx, gomock.Any()).Return(nil, errors.New("error updating cluster config"))


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->
kind/bug
**What this PR does / why we need it**:
This PR added support for default Public CIDR to be set whenever a IPv6 rancher server tries to provision an Ipv6 rancher eks cluster
<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue https://github.com/rancher/rancher/issues/54475

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
